### PR TITLE
Bug fix in tip/tilt definitions.

### DIFF
--- a/models/model_Jacobian.m
+++ b/models/model_Jacobian.m
@@ -33,8 +33,8 @@ function jacStruct = model_Jacobian(mp, DM)
 
     %--Calculate the starting DM surfaces beforehand to save time.
     %--Compute the DM surfaces outside the full model to save lots of time
-    if(any(DM.dm_ind==1)); DM.dm1.compact.surfM = falco_gen_dm_surf(DM.dm1, DM.dm1.compact.dx,DM.dm1.compact.NdmPad); else DM.dm1.compact.surfM = zeros(2); end;
-    if(any(DM.dm_ind==2)); DM.dm2.compact.surfM = falco_gen_dm_surf(DM.dm2, DM.dm2.compact.dx,DM.dm2.compact.NdmPad); else DM.dm2.compact.surfM = zeros(2); end;
+    if(any(DM.dm_ind==1)); DM.dm1.compact.surfM = falco_gen_dm_surf(DM.dm1, DM.dm1.compact.dx,DM.dm1.compact.NdmPad); else; DM.dm1.compact.surfM = zeros(2); end
+    if(any(DM.dm_ind==2)); DM.dm2.compact.surfM = falco_gen_dm_surf(DM.dm2, DM.dm2.compact.dx,DM.dm2.compact.NdmPad); else; DM.dm2.compact.surfM = zeros(2); end
 
 
     %--Get rid of the DM.dmX.inf_datacube fields in the full model because they are HUGE and will

--- a/models/model_Jacobian_LC.m
+++ b/models/model_Jacobian_LC.m
@@ -54,9 +54,10 @@ NdmPad = DM.compact.NdmPad;
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %--Include the tip/tilt in the input wavefront
-if(isfield(mp,'ttx'))  % #NEWFORTIPTILT
-    x_offset = mp.ttx(modvar.ttIndex); 
-    y_offset = mp.tty(modvar.ttIndex); 
+if(isfield(mp,'ttx'))
+    %--Scale by lambda/lambda0 because ttx and tty are in lambda0/D
+    x_offset = mp.ttx(modvar.ttIndex)*(mp.lambda0/lambda);
+    y_offset = mp.tty(modvar.ttIndex)*(mp.lambda0/lambda);
 
     TTphase = (-1)*(2*pi*(x_offset*mp.P2.compact.XsDL + y_offset*mp.P2.compact.YsDL));
     Ett = exp(1i*TTphase*mp.lambda0/lambda);

--- a/models/model_Jacobian_SPLC.m
+++ b/models/model_Jacobian_SPLC.m
@@ -48,9 +48,10 @@ mirrorFac = 2; % Phase change is twice the DM surface height.f
 NdmPad = DM.compact.NdmPad;
 
 %--Include the tip/tilt in the input wavefront
-if(isfield(mp,'ttx'))  % #NEWFORTIPTILT
-    x_offset = mp.ttx(modvar.ttIndex);
-    y_offset = mp.tty(modvar.ttIndex);
+if(isfield(mp,'ttx'))
+    %--Scale by lambda/lambda0 because ttx and tty are in lambda0/D
+    x_offset = mp.ttx(modvar.ttIndex)*(mp.lambda0/lambda);
+    y_offset = mp.tty(modvar.ttIndex)*(mp.lambda0/lambda);
 
     TTphase = (-1)*(2*pi*(x_offset*mp.P2.compact.XsDL + y_offset*mp.P2.compact.YsDL));
     Ett = exp(1i*TTphase*mp.lambda0/lambda);

--- a/models/model_compact_LC.m
+++ b/models/model_compact_LC.m
@@ -52,8 +52,9 @@ NdmPad = DM.compact.NdmPad;
 
 %--Include the tip/tilt in the input wavefront
 if(isfield(mp,'ttx'))
-    x_offset = mp.ttx(modvar.ttIndex);
-    y_offset = mp.tty(modvar.ttIndex);
+    %--Scale by lambda/lambda0 because ttx and tty are in lambda0/D
+    x_offset = mp.ttx(modvar.ttIndex)*(mp.lambda0/lambda);
+    y_offset = mp.tty(modvar.ttIndex)*(mp.lambda0/lambda);
 
     TTphase = (-1)*(2*pi*(x_offset*mp.P2.compact.XsDL + y_offset*mp.P2.compact.YsDL));
     Ett = exp(1i*TTphase*mp.lambda0/lambda);

--- a/models/model_compact_SPLC.m
+++ b/models/model_compact_SPLC.m
@@ -48,8 +48,9 @@ NdmPad = DM.compact.NdmPad;
 
 %--Include the tip/tilt in the input wavefront
 if(isfield(mp,'ttx'))
-    x_offset = mp.ttx(modvar.ttIndex);
-    y_offset = mp.tty(modvar.ttIndex);
+    %--Scale by lambda/lambda0 because ttx and tty are in lambda0/D
+    x_offset = mp.ttx(modvar.ttIndex)*(mp.lambda0/lambda);
+    y_offset = mp.tty(modvar.ttIndex)*(mp.lambda0/lambda);
 
     TTphase = (-1)*(2*pi*(x_offset*mp.P2.compact.XsDL + y_offset*mp.P2.compact.YsDL));
     Ett = exp(1i*TTphase*mp.lambda0/lambda);

--- a/models/model_compact_VC.m
+++ b/models/model_compact_VC.m
@@ -50,8 +50,9 @@ NdmPad = DM.compact.NdmPad;
 
 %--Include the tip/tilt in the input wavefront
 if(isfield(mp,'ttx'))
-    x_offset = mp.ttx(modvar.ttIndex);
-    y_offset = mp.tty(modvar.ttIndex);
+    %--Scale by lambda/lambda0 because ttx and tty are in lambda0/D
+    x_offset = mp.ttx(modvar.ttIndex)*(mp.lambda0/lambda);
+    y_offset = mp.tty(modvar.ttIndex)*(mp.lambda0/lambda);
 
     TTphase = (-1)*(2*pi*(x_offset*mp.P2.compact.XsDL + y_offset*mp.P2.compact.YsDL));
     Ett = exp(1i*TTphase*mp.lambda0/lambda);

--- a/models/model_full_LC.m
+++ b/models/model_full_LC.m
@@ -62,9 +62,10 @@ elseif strcmpi(modvar.whichSource,'offaxis') %--Use for throughput calculations
         
 else % Default to using the starlight
     %--Include the tip/tilt in the input stellar wavefront
-    if(isfield(mp,'ttx'))  % #NEWFORTIPTILT
-        x_offset = mp.ttx(modvar.ttIndex);
-        y_offset = mp.tty(modvar.ttIndex);
+    if(isfield(mp,'ttx'))
+        %--Scale by lambda/lambda0 because ttx and tty are in lambda0/D
+        x_offset = mp.ttx(modvar.ttIndex)*(mp.lambda0/lambda);
+        y_offset = mp.tty(modvar.ttIndex)*(mp.lambda0/lambda);
 
         TTphase = (-1)*(2*pi*(x_offset*mp.P2.full.XsDL + y_offset*mp.P2.full.YsDL));
         Ett = exp(1i*TTphase*mp.lambda0/lambda);

--- a/models/model_full_SPLC.m
+++ b/models/model_full_SPLC.m
@@ -60,9 +60,10 @@ elseif strcmpi(modvar.whichSource,'offaxis') %--Use for throughput calculations
     
 else % Default to using the starlight
     %--Include the tip/tilt in the input stellar wavefront
-    if(isfield(mp,'ttx'))  % #NEWFORTIPTILT
-        x_offset = mp.ttx(modvar.ttIndex);
-        y_offset = mp.tty(modvar.ttIndex);
+    if(isfield(mp,'ttx'))
+        %--Scale by lambda/lambda0 because ttx and tty are in lambda0/D
+        x_offset = mp.ttx(modvar.ttIndex)*(mp.lambda0/lambda);
+        y_offset = mp.tty(modvar.ttIndex)*(mp.lambda0/lambda);
 
         TTphase = (-1)*(2*pi*(x_offset*mp.P2.full.XsDL + y_offset*mp.P2.full.YsDL));
         Ett = exp(1i*TTphase*mp.lambda0/lambda);

--- a/models/model_full_VC.m
+++ b/models/model_full_VC.m
@@ -58,9 +58,10 @@ elseif strcmpi(modvar.whichSource,'offaxis') %--Use for throughput calculations
         
 else % Default to using the starlight
     %--Include the tip/tilt in the input stellar wavefront
-    if(isfield(mp,'ttx'))  % #NEWFORTIPTILT
-        x_offset = mp.ttx(modvar.ttIndex);
-        y_offset = mp.tty(modvar.ttIndex);
+    if(isfield(mp,'ttx'))
+        %--Scale by lambda/lambda0 because ttx and tty are in lambda0/D
+        x_offset = mp.ttx(modvar.ttIndex)*(mp.lambda0/lambda);
+        y_offset = mp.tty(modvar.ttIndex)*(mp.lambda0/lambda);
 
         TTphase = (-1)*(2*pi*(x_offset*mp.P2.full.XsDL + y_offset*mp.P2.full.YsDL));
         Ett = exp(1i*TTphase*mp.lambda0/lambda);


### PR DESCRIPTION
Tip/tilt offset locations are now constant in sky angle when used in
the full, compact, and Jacobian models. Before they were accidentally
scaling linearly with wavelength.