### PR TITLE
Bug fix for Zernike sensitivity control.

### DIFF
--- a/models/model_Jacobian_EHLC.m
+++ b/models/model_Jacobian_EHLC.m
@@ -66,6 +66,7 @@ end
 if(modvar.zernIndex~=1)
     indsZnoll = modvar.zernIndex; %--Just send in 1 Zernike mode
     zernMat = falco_gen_norm_zernike_maps(mp.P1.compact.Nbeam,mp.centering,indsZnoll); %--Cube of normalized (RMS = 1) Zernike modes.
+    zernMat = padOrCropEven(zernMat,mp.P1.compact.Narr);
     % figure(1); imagesc(zernMat); axis xy equal tight; colorbar; 
     Ein = Ein.*zernMat*(2*pi*1i/lambda)*mp.jac.Zcoef(indZernVec);
 end

--- a/models/model_Jacobian_FOHLC.m
+++ b/models/model_Jacobian_FOHLC.m
@@ -62,6 +62,7 @@ Ein = mp.P1.compact.E(:,:,modvar.sbpIndex);
 if(modvar.zernIndex~=1)
     indsZnoll = modvar.zernIndex; %--Just send in 1 Zernike mode
     zernMat = falco_gen_norm_zernike_maps(mp.P1.compact.Nbeam,mp.centering,indsZnoll); %--Cube of normalized (RMS = 1) Zernike modes.
+    zernMat = padOrCropEven(zernMat,mp.P1.compact.Narr);
     % figure(1); imagesc(zernMat); axis xy equal tight; colorbar; 
     Ein = Ein.*zernMat*(2*pi*1i/lambda)*mp.jac.Zcoef(indZernVec);
 end

--- a/models/model_Jacobian_HLC.m
+++ b/models/model_Jacobian_HLC.m
@@ -59,6 +59,7 @@ Ein = mp.P1.compact.E(:,:,modvar.sbpIndex);
 if(modvar.zernIndex~=1)
     indsZnoll = modvar.zernIndex; %--Just send in 1 Zernike mode
     zernMat = falco_gen_norm_zernike_maps(mp.P1.compact.Nbeam,mp.centering,indsZnoll); %--Cube of normalized (RMS = 1) Zernike modes.
+    zernMat = padOrCropEven(zernMat,mp.P1.compact.Narr);
     % figure(1); imagesc(zernMat); axis xy equal tight; colorbar; 
     Ein = Ein.*zernMat*(2*pi*1i/lambda)*mp.jac.Zcoef(indZernVec);
 end

--- a/models/model_Jacobian_LC.m
+++ b/models/model_Jacobian_LC.m
@@ -59,6 +59,7 @@ Ein = mp.P1.compact.E(:,:,modvar.sbpIndex);
 if(modvar.zernIndex~=1)
     indsZnoll = modvar.zernIndex; %--Just send in 1 Zernike mode
     zernMat = falco_gen_norm_zernike_maps(mp.P1.compact.Nbeam,mp.centering,indsZnoll); %--Cube of normalized (RMS = 1) Zernike modes.
+    zernMat = padOrCropEven(zernMat,mp.P1.compact.Narr);
     % figure(1); imagesc(zernMat); axis xy equal tight; colorbar; 
     Ein = Ein.*zernMat*(2*pi*1i/lambda)*mp.jac.Zcoef(indZernVec);
 end

--- a/models/model_Jacobian_Roddier.m
+++ b/models/model_Jacobian_Roddier.m
@@ -60,6 +60,7 @@ Ein = mp.P1.compact.E(:,:,modvar.sbpIndex);
 if(modvar.zernIndex~=1)
     indsZnoll = modvar.zernIndex; %--Just send in 1 Zernike mode
     zernMat = falco_gen_norm_zernike_maps(mp.P1.compact.Nbeam,mp.centering,indsZnoll); %--Cube of normalized (RMS = 1) Zernike modes.
+    zernMat = padOrCropEven(zernMat,mp.P1.compact.Narr);
     % figure(1); imagesc(zernMat); axis xy equal tight; colorbar; 
     Ein = Ein.*zernMat*(2*pi*1i/lambda)*mp.jac.Zcoef(indZernVec);
 end

--- a/models/model_Jacobian_SPLC.m
+++ b/models/model_Jacobian_SPLC.m
@@ -56,6 +56,7 @@ Ein = mp.P1.compact.E(:,:,modvar.sbpIndex);
 if(modvar.zernIndex~=1)
     indsZnoll = modvar.zernIndex; %--Just send in 1 Zernike mode
     zernMat = falco_gen_norm_zernike_maps(mp.P1.compact.Nbeam,mp.centering,indsZnoll); %--Cube of normalized (RMS = 1) Zernike modes.
+    zernMat = padOrCropEven(zernMat,mp.P1.compact.Narr);
     % figure(1); imagesc(zernMat); axis xy equal tight; colorbar; 
     Ein = Ein.*zernMat*(2*pi*1i/lambda)*mp.jac.Zcoef(indZernVec);
 end

--- a/models/model_Jacobian_VC.m
+++ b/models/model_Jacobian_VC.m
@@ -59,6 +59,7 @@ Ein = mp.P1.compact.E(:,:,modvar.sbpIndex);
 if(modvar.zernIndex~=1)
     indsZnoll = modvar.zernIndex; %--Just send in 1 Zernike mode
     zernMat = falco_gen_norm_zernike_maps(mp.P1.compact.Nbeam,mp.centering,indsZnoll); %--Cube of normalized (RMS = 1) Zernike modes.
+    zernMat = padOrCropEven(zernMat,mp.P1.compact.Narr);
     % figure(1); imagesc(zernMat); axis xy equal tight; colorbar; 
     Ein = Ein.*zernMat*(2*pi*1i/lambda)*mp.jac.Zcoef(indZernVec);
 end

--- a/models/model_compact.m
+++ b/models/model_compact.m
@@ -111,6 +111,7 @@ if(modvar.zernIndex~=1)
     indZernVec = find(mp.jac.zerns==modvar.zernIndex); %--Index in vector of RMS values for Zernikes.
     indsZnoll = modvar.zernIndex; %--Just send in 1 Zernike mode
     zernMat = falco_gen_norm_zernike_maps(mp.P1.compact.Nbeam,mp.centering,indsZnoll); %--Cube of normalized (RMS = 1) Zernike modes.
+    zernMat = padOrCropEven(zernMat,mp.P1.compact.Narr);
     % figure(1); imagesc(zernMat); axis xy equal tight; colorbar; 
     Ein = Ein.*zernMat*(2*pi*1i/lambda)*mp.jac.Zcoef(indZernVec);
 end

--- a/models/model_full.m
+++ b/models/model_full.m
@@ -113,6 +113,7 @@ end
 if(modvar.zernIndex~=1)
     indsZnoll = modvar.zernIndex; %--Just send in 1 Zernike mode
     zernMat = falco_gen_norm_zernike_maps(mp.P1.full.Nbeam,mp.centering,indsZnoll); %--Cube of normalized (RMS = 1) Zernike modes.
+    zernMat = padOrCropEven(zernMat,mp.P1.full.Narr);
     % figure(1); imagesc(zernMat); axis xy equal tight; colorbar; 
     Ein = Ein.*zernMat*(2*pi/lambda)*mp.jac.Zcoef(modvar.zernIndex);
 end


### PR DESCRIPTION
Bug was fixed where Zernike sensitivities couldn't be suppressed if the size of the pupil array (mp.P1.compact.Narr and mp.P1.full.Narr) was defined differently from the default of being just large enough to contain the aperture. The array for the Zernike mode is now padded/cropped to the same size.