### PR TITLE
Bug fix and more features

### DIFF
--- a/config/EXAMPLE_defaults_DST_FLC_design.m
+++ b/config/EXAMPLE_defaults_DST_FLC_design.m
@@ -247,6 +247,7 @@ mp.F3.full.res = 6;    % sampling of FPM for full model [pixels per lambda0/D]
 mp.whichPupil = 'Simple';
 mp.P1.IDnorm = 0.00; %--ID of the central obscuration [diameter]. Used only for computing the RMS DM surface from the ID to the OD of the pupil. OD is assumed to be 1.
 mp.P1.ODnorm = 1.00;% Outer diameter of the telescope [diameter]
+mp.P1.stretch = 1.00; % factor that stretches the horizontal axis to create elliptical beam 
 mp.P1.D = 4; %--telescope diameter [meters]. Used only for converting milliarcseconds to lambda0/D or vice-versa.
 mp.P1.Dfac = 1; %--Factor scaling inscribed OD to circumscribed OD for the telescope pupil.
 mp.P1.Nstrut = 0;% Number of struts 

--- a/config/EXAMPLE_defaults_DST_LC_design.m
+++ b/config/EXAMPLE_defaults_DST_LC_design.m
@@ -247,6 +247,7 @@ mp.F3.full.res = 6;    % sampling of FPM for full model [pixels per lambda0/D]
 mp.whichPupil = 'Simple';
 mp.P1.IDnorm = 0.00; %--ID of the central obscuration [diameter]. Used only for computing the RMS DM surface from the ID to the OD of the pupil. OD is assumed to be 1.
 mp.P1.ODnorm = 1.00;% Outer diameter of the telescope [diameter]
+mp.P1.stretch = 1.00; % factor that stretches the horizontal axis to create elliptical beam 
 mp.P1.D = 4; %--telescope diameter [meters]. Used only for converting milliarcseconds to lambda0/D or vice-versa.
 mp.P1.Dfac = 1; %--Factor scaling inscribed OD to circumscribed OD for the telescope pupil.
 mp.P1.Nstrut = 0;% Number of struts 

--- a/lib/plot/falco_plot_progress.m
+++ b/lib/plot/falco_plot_progress.m
@@ -6,6 +6,9 @@
 %
 function handles = falco_plot_progress(handles,mp,Itr,contrast_bandavg,Im,DM1surf,DM2surf)
 
+%--Prevent the log10(Im) plot from getting complex values.
+ImNonneg = Im;
+ImNonneg(Im<0) = 0;
 
 if(mp.flagPlot)
     fig_size = [100          60        1500         900];
@@ -119,7 +122,7 @@ if(mp.flagPlot)
     ax2=get(h_psf,'position'); % Save the position as ax
     set(h_psf,'position',ax2); % Manually setting this holds the position with colorbar 
     subplot(2,3,2); 
-    imagesc(mp.Fend.xisDL,mp.Fend.etasDL,log10(Im),[-10 -3]); 
+    imagesc(mp.Fend.xisDL,mp.Fend.etasDL,log10(ImNonneg),[-10 -3]); 
     axis xy equal tight; ch_psf=colorbar; colormap parula;
     xlabel('$\lambda_0$/D','FontSize',16,'Interpreter','LaTeX'); 
     ylabel('$\lambda_0$/D','FontSize',16,'Interpreter','LaTeX');

--- a/lib/wfsc/falco_ctrl_EFCcon_base.m
+++ b/lib/wfsc/falco_ctrl_EFCcon_base.m
@@ -127,6 +127,7 @@ cvx_begin quiet
 
         duVec <= cvar.du_UB_comb
         duVec >= cvar.du_LB_comb
+        (cvar.uVec+duVec).'*(cvar.uVec+duVec) <= (cvar.NeleAll*mp.ctrl.VrmsMax^2)
 
 cvx_end
 

--- a/lib/wfsc/falco_ctrl_planned_EFCcon.m
+++ b/lib/wfsc/falco_ctrl_planned_EFCcon.m
@@ -121,7 +121,7 @@ function [dDM,cvar] = falco_ctrl_planned_EFCcon(mp, cvar)
         end
         vals_list = [log10regSchedOut; cvar.latestBestDMfac];
         
-        [cvar.cMin,dDM] = falco_ctrl_EFC_base(ni,vals_list,mp,cvar);
+        [cvar.cMin,dDM] = falco_ctrl_EFCcon_base(ni,vals_list,mp,cvar);
         fprintf('Scheduled log10reg = %.1f\t gives %4.2e contrast.\n',log10regSchedOut,cvar.cMin)
 %         fprintf('Scheduled values of: \tlog10reg = %.1f,\t dmfac = %.2f\t   gives %4.2e contrast.\n',log10regSchedOut,cvar.latestBestDMfac,cvar.cMin)
 

--- a/main/EXAMPLE_BetaTesting_main_WFIRST_FOHLC_CVX.m
+++ b/main/EXAMPLE_BetaTesting_main_WFIRST_FOHLC_CVX.m
@@ -1,0 +1,148 @@
+% Copyright 2018, 2019, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+%
+%--Script to perform an HLC design run.
+%  1) Load the default model parameters for a FOHLC.
+%  2) Specify the values to overwrite.
+%  3) Run a single trial of WFC using FALCO.
+%
+% REVISION HISTORY:
+% --------------
+% Modified on 2019-02-26 by A.J. Riggs to load the defaults first.
+% ---------------
+
+clear all;
+close all;
+
+%% Step 1: Define Necessary Paths on Your Computer System
+
+%--Library locations. FALCO and PROPER are required. CVX is optional.
+mp.path.falco = '~/Repos/falco-matlab/';  %--Location of FALCO
+mp.path.proper = '~/Documents/MATLAB/PROPER/'; %--Location of the MATLAB PROPER library
+mp.path.cvx = '~/Documents/MATLAB/cvx/'; %--Location of MATLAB CVX
+
+%%--Output Data Directories (Comment these lines out to use defaults within falco-matlab/data/ directory.)
+mp.path.config = '~/Repos/falco-matlab/data/brief/'; %--Location of config files and minimal output files. Default is [mainPath filesep 'data' filesep 'brief' filesep]
+mp.path.ws = '~/Repos/falco-matlab/data/ws/'; % (Mostly) complete workspace from end of trial. Default is [mainPath filesep 'data' filesep 'ws' filesep];
+
+%%--Add to the MATLAB Path
+addpath(genpath(mp.path.falco)) %--Add FALCO library to MATLAB path
+addpath(genpath(mp.path.proper)) %--Add PROPER library to MATLAB path
+addpath(genpath(mp.path.cvx)) %--Add CVX to MATLAB path
+rmpath([mp.path.cvx 'lib/narginchk_:']) %--Legend plotting issue if CVX's narginchk function is used instead of Matlab's default function.
+
+
+%% Step 2: Load default model parameters
+
+EXAMPLE_defaults_WFIRST_FOHLC
+
+
+%% Step 3: Overwrite default values as desired
+
+%%--Special Computational Settings
+mp.flagParfor = true;%false; %--whether to use parfor for Jacobian calculation
+mp.flagPlot = true;
+
+%--Record Keeping
+mp.SeriesNum = 1;
+mp.TrialNum = 1;
+
+%%--[OPTIONAL] Start from a previous FALCO trial's DM settings
+% fn_prev = 'ws_Series0002_Trial0001_HLC_WFIRST20180103_2DM48_z1_IWA2.7_OWA10_6lams575nm_BW12.5_EFC_30its.mat';
+% temp = load(fn_prev,'out');
+% mp.dm1.V = temp.out.DM1V;
+% mp.dm2.V = temp.out.DM2V;
+% clear temp
+
+%--Use just 1 wavelength for initial debugging of code
+mp.fracBW = 0.10;%0.01;       %--fractional bandwidth of the whole bandpass (Delta lambda / lambda0)
+mp.Nsbp = 5;%1;            %--Number of sub-bandpasses to divide the whole bandpass into for estimation and control
+
+% mp.F3.Rin = 5;%2.7;%4;%2.7; % maximum radius of inner part of the focal plane mask, in lambda0/D
+% mp.F3.RinA = 2.7;%mp.F3.Rin; % inner hard-edge radius of the focal plane mask (lambda0/D). Needs to be <= mp.F3.Rin 
+
+%--Use just 1 wavelength for initial debugging of code
+mp.fracBW = 0.01;       %--fractional bandwidth of the whole bandpass (Delta lambda / lambda0)
+mp.Nsbp = 1;            %--Number of sub-bandpasses to divide the whole bandpass into for estimation and control
+mp.flagParfor = false; %--whether to use parfor for Jacobian calculation
+
+
+%--Zernikes to suppress with controller
+mp.jac.zerns = 1;%[1,2,3];  %--Which Zernike modes to include in Jacobian. Given as the max Noll index. Always include the value "1" for the on-axis piston mode.
+mp.jac.Zcoef = [1, 1e-9, 1e-9];%1e-9*ones(size(mp.jac.zerns)); %--meters RMS of Zernike aberrations. (piston value is reset to 1 later)
+  
+mp.dm9.weight = 20;%5;%20;
+mp.dm9.V0coef = 0;%50;%200;%0; %--Starting voltages of DM9
+mp.dm8.weight = 1e-2;%2e-2;% 1e-2;%1e1;%1; % Jacobian weight for the FPM dielectric. Smaller weight makes stroke larger by the inverse of this factor.
+mp.dm8.act_sens = 8e-1;%3e-1;%1;%3e-1; %--Change in oomph (E-field sensitivity) of DM8 actuators. Chosen empirically based on how much DM8 actuates during a control step. Larger than 1 is way too strong.
+
+
+mp.F3.Rin = 3;    % maximum radius of inner part of the focal plane mask [lambda0/D]
+mp.F3.RinA = 2.7;   % inner hard-edge radius of the focal plane mask [lambda0/D]. Needs to be <= mp.F3.Rin 
+
+mp.dm9.actres = 6;% 4; % number of "actuators" per lambda0/D in the FPM's focal plane. On a square actuator array.
+
+mp.F3.compact.res = mp.dm9.actres/mp.dm9.dx_inf0_act;
+mp.F3.full.res = mp.dm9.actres/mp.dm9.dx_inf0_act;
+mp.dm9.Nact = ceil_even(2*mp.F3.Rin*mp.dm9.actres); % number of actuators across DM9 (if not in a hex grid)
+
+
+
+%%
+mp.controller = 'plannedEFCcon';
+
+cvx_startup %--MUST HAVE THIS LINE TO START CVX
+cvx_solver Mosek
+cvx_precision default %--Options: low, medium, default, high, best
+
+% % PLANNED EFC-Constrained values:
+mp.ctrl.VrmsMax = 20; %--Approximate RMS cap on the actuation. Need to verify the equation this is in.
+
+mp.dm_ind = [1 2 ]; % vector of DMs used in controller at ANY time (not necessarily all at once or all the time). 
+mp.ctrl.dmfacVec = 1;
+%--CONTROL SCHEDULE. Columns of mp.ctrl.sched_mat are: 
+    % Column 1: # of iterations, 
+    % Column 2: log10(regularization), 
+    % Column 3: which DMs to use (12, 128, 129, or 1289) for control
+    % Column 4: flag (0 = false, 1 = true), whether to re-linearize
+    %   at that iteration.
+    % Column 5: flag (0 = false, 1 = true), whether to perform an
+    %   EFC parameter grid search to find the set giving the best
+    %   contrast .
+    % The imaginary part of the log10(regularization) in column 2 is
+    %  replaced for that iteration with the optimal log10(regularization)
+    % A row starting with [0, 0, 0, 1...] is for relinearizing only at that time
+
+mp.ctrl.sched_mat = [...
+    repmat([1, -7, 12,1,0],[2,1]);...
+    repmat([1, -6, 12,1,0],[5,1]);...
+    repmat([1, -4, 12,1,0],[5,1]);...
+    repmat([1, -3, 12,1,0],[5,1]);...
+    ];
+[mp.Nitr, mp.relinItrVec, mp.gridSearchItrVec, mp.ctrl.log10regSchedIn, mp.dm_ind_sched] = falco_ctrl_EFC_schedule_generator(mp.ctrl.sched_mat);
+
+%--Delta voltage range restrictions
+mp.dm1.maxAbsdV = 100;
+mp.dm2.maxAbsdV = 100;
+mp.dm9.maxAbsdV = 50;
+
+%--Absolute voltage range restrictions
+mp.dm1.maxAbsV = 100;
+mp.dm2.maxAbsV = 100; 
+
+%% Step 4: Generate the label associated with this trial
+
+mp.runLabel = ['Series',num2str(mp.SeriesNum,'%04d'),'_Trial',num2str(mp.TrialNum,'%04d_'),...
+    mp.coro,'_',mp.whichPupil,'_',num2str(numel(mp.dm_ind)),'DM',num2str(mp.dm1.Nact),'_z',num2str(mp.d_dm1_dm2),...
+    '_IWA',num2str(mp.Fend.corr.Rin),'_OWA',num2str(mp.Fend.corr.Rout),...
+    '_',num2str(mp.Nsbp),'lams',num2str(round(1e9*mp.lambda0)),'nm_BW',num2str(mp.fracBW*100),...
+    '_',mp.controller];
+
+
+%% Step 5: Perform the Wavefront Sensing and Control
+
+out = falco_wfsc_loop(mp);
+

--- a/main/EXAMPLE_main_DST_DMLC_probing.m
+++ b/main/EXAMPLE_main_DST_DMLC_probing.m
@@ -57,12 +57,11 @@ mp.TrialNum = 1;
 % mp.dm2.V = temp.out.DM2V;
 % clear temp
 
-% mp.estimator = 'perfect';
-
-% %--Use just 1 wavelength for initial debugging of code
+% %--DEBUGGING
 % mp.fracBW = 0.01;     %--fractional bandwidth of the whole bandpass (Delta lambda / lambda0)
 % mp.Nsbp = 1;          %--Number of sub-bandpasses to divide the whole bandpass into for estimation and control
-
+% mp.flagParfor = false; %--whether to use parfor for Jacobian calculation
+% % mp.estimator = 'perfect';
 
 %% Step 4: Generate the label associated with this trial
 


### PR DESCRIPTION
- Bug fix for DST scripts. The new variable mp.P1.stretch was added to the config files since this variable is now a necessary input for generating a Simple pupil.
- Bug fix for image plotting. Negative values are zeroed out in the image before plotting the log10 of it so that imagesc() does not give an error.
- New feature: can now use the Jacobian to generate the observation matrix in the pair-wise probing estimator. This is helpful for adaptive estimation and control that improves the Jacobian. Set by the variable mp.est.flagUseJac.
- New feature : now added a script that calls the (debugged) constrained planned EFC controller that uses CVX. It runs but so far does not give as good a dark hole as regular (unconstrained) EFC.