### PR TITLE
Changed intensity normalization back to old way for vortex

### DIFF
--- a/models/model_compact_general.m
+++ b/models/model_compact_general.m
@@ -217,13 +217,13 @@ switch upper(mp.coro)
 
 end
   
-% %--Remove the FPM completely if normalization value is being found
-% if(normFac==0)
-%     switch upper(mp.coro)
-%         case{'VORTEX','VC','AVC'}
-%             EP4 = propcustom_relay(EP3,mp.Nrelay3to4, mp.centering);
-%     end
-% end
+%--Remove the FPM completely if normalization value is being found
+if(normFac==0)
+    switch upper(mp.coro)
+        case{'VORTEX','VC','AVC'}
+            EP4 = propcustom_relay(EP3,mp.Nrelay3to4, mp.centering);
+    end
+end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%  Back to common propagation any coronagraph type   %%%%%%%%%%%%%

--- a/models/model_full_Fourier.m
+++ b/models/model_full_Fourier.m
@@ -221,14 +221,14 @@ switch upper(mp.coro)
         error('model_full_Fourier.m: Modely type\t %s\t not recognized.\n',mp.coro);
 end
 
-% %--Remove the FPM completely if normalization value is being found
-% if(normFac==0)
-%     switch upper(mp.coro)
-%         case{'VORTEX','VC','AVC'}
-%             EP4 = propcustom_2FT(EP3, mp.centering);
-%             EP4 = padOrCropEven(EP4,mp.P4.full.Narr);
-%     end
-% end
+%--Remove the FPM completely if normalization value is being found
+if(normFac==0)
+    switch upper(mp.coro)
+        case{'VORTEX','VC','AVC'}
+            EP4 = propcustom_2FT(EP3, mp.centering);
+            EP4 = padOrCropEven(EP4,mp.P4.full.Narr);
+    end
+end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%  Back to common propagation any coronagraph type   %%%%%%%%%%%%%


### PR DESCRIPTION
Changed intensity normalization back to the old way for vortex coronagraphs. Occulting spot FPMs should be fine with the off-axis source normalization method instead.