### PR TITLE
Bug fix and syntax improvement in model outputs

### DIFF
--- a/config/EXAMPLE_defaults_VC_simple.m
+++ b/config/EXAMPLE_defaults_VC_simple.m
@@ -54,7 +54,7 @@ mp.est.probe.radius = 12;    % Max x/y extent of probed region [actuators].
 mp.est.probe.offsetX = 0;   % offset of probe center in x [actuators]. Use to avoid central obscurations.
 mp.est.probe.offsetY = 0;    % offset of probe center in y [actuators]. Use to avoid central obscurations.
 mp.est.probe.axis = 'alternate';     % which axis to have the phase discontinuity along [x or y or xy/alt/alternate]
-mp.est.probe.gainFudge = 5;     % empirical fudge factor to make average probe amplitude match desired value.
+mp.est.probe.gainFudge = 1;     % empirical fudge factor to make average probe amplitude match desired value.
 
 %--New variables for pairwise probing with a Kalman filter
 %  mp.est.ItrStartKF =  %Which correction iteration to start recursive estimate

--- a/lib/masks/falco_gen_SW_mask.m
+++ b/lib/masks/falco_gen_SW_mask.m
@@ -111,11 +111,11 @@ else
     clockAng = inputs.clockAngDeg*pi/180;
 end
 
-maskSW = maskSW0 & abs(angle(exp(1i*(THETA-clockAng))))<angRad/2;
+maskSW = maskSW0 & abs(angle(exp(1i*(THETA-clockAng))))<=angRad/2;
 
 if(strcmpi(whichSide,'both'))
     clockAng = clockAng + pi;
-    maskSW2 = maskSW0 & abs(angle(exp(1i*(THETA-clockAng))))<angRad/2;
+    maskSW2 = maskSW0 & abs(angle(exp(1i*(THETA-clockAng))))<=angRad/2;
     maskSW = or(maskSW,maskSW2);
 end
 

--- a/lib/wfsc/falco_est_pairwise_probing.m
+++ b/lib/wfsc/falco_est_pairwise_probing.m
@@ -133,7 +133,7 @@ for si=1:mp.Nsbp
 
     % Set (approximate) probe intensity based on current measured Inorm
     ev.InormProbeMax = 1e-4;
-    InormProbe = min( [sqrt(mean(I0vec)*1e-5), ev.InormProbeMax]); %--Change this to a high percentile value (e.g., 90%) instead of the max to avoid being tricked by noise
+    InormProbe = min( [sqrt(max(I0vec)*1e-5), ev.InormProbeMax]); %--Change this to a high percentile value (e.g., 90%) instead of the max to avoid being tricked by noise
     fprintf('Chosen probe intensity: %.2e \n',InormProbe);    
 
     %--Perform the probing

--- a/lib/wfsc/falco_est_pairwise_probing.m
+++ b/lib/wfsc/falco_est_pairwise_probing.m
@@ -133,7 +133,7 @@ for si=1:mp.Nsbp
 
     % Set (approximate) probe intensity based on current measured Inorm
     ev.InormProbeMax = 1e-4;
-    InormProbe = min( [sqrt(max(I0vec)*1e-5), ev.InormProbeMax]); %--Change this to a high percentile value (e.g., 90%) instead of the max to avoid being tricked by noise
+    InormProbe = min( [sqrt(mean(I0vec)*1e-5), ev.InormProbeMax]); %--Change this to a high percentile value (e.g., 90%) instead of the max to avoid being tricked by noise
     fprintf('Chosen probe intensity: %.2e \n',InormProbe);    
 
     %--Perform the probing

--- a/models/model_compact.m
+++ b/models/model_compact.m
@@ -10,10 +10,12 @@
 %
 % REVISION HISTORY:
 % --------------
+% Modified on 2019-04-18 by A.J. Riggs to use varargout for Efiber instead
+% of having Efiber as a required output. 
 % Modified on 2017-10-17 by A.J. Riggs to have model_compact.m be a wrapper. All the 
 %  actual compact models have been moved to sub-routines for clarity.
-% Modified on 19 June 2017 by A.J. Riggs to use lower resolution than the
-%   full model.
+% Modified on 19 June 2017 by A.J. Riggs to use resolutions independent of 
+% the full model.
 % model_compact.m - 18 August 2016: Modified from hcil_model.m
 % hcil_model.m - 18 Feb 2015: Modified from HCIL_model_lab_BB_v3.m
 % ---------------
@@ -24,17 +26,13 @@
 %
 % OUTPUTS:
 % -Eout
-%  -> Note: When computing the control Jacobian, Eout is a structure
-%  containing the Jacobians. Otherwise, it is just the E-field at the
-%  second focal plane.
+% -
 %
-% modvar structure fields (4):
+% modvar structure fields required for model_compact:
 % -sbpIndex
-% -wpsbpIndex
 % -whichSource
-% -flagGenMat
 
-function [Eout, Efiber] = model_compact(mp, modvar,varargin)
+function [Eout, varargout] = model_compact(mp, modvar,varargin)
 
 modvar.wpsbpIndex = 0; %--Dummy index since not needed in compact model
 
@@ -132,7 +130,12 @@ end
 %--Select which optical layout's compact model to use and get the output E-field
 switch lower(mp.layout)
     case{'fourier'}
-        [Eout, Efiber] = model_compact_general(mp, lambda, Ein, normFac, flagEval);
+        if(mp.flagFiber)
+            [Eout, Efiber] = model_compact_general(mp, lambda, Ein, normFac, flagEval);
+            varargout{1} = Efiber;
+        else
+            Eout = model_compact_general(mp, lambda, Ein, normFac, flagEval);
+        end
         
     case{'wfirst_phaseb_simple','wfirst_phaseb_proper'} %--Use compact model as the full model, and the general FALCO model as the compact model, or %--Use the actual Phase B compact model as the compact model.
         switch upper(mp.coro)

--- a/models/model_full.m
+++ b/models/model_full.m
@@ -11,6 +11,8 @@
 %
 % REVISION HISTORY:
 % --------------
+% Modified on 2019-04-18 by A.J. Riggs to use varargout for Efiber instead
+% of having Efiber as a required output. 
 % Modified on 2017-10-17 by A.J. Riggs to have model_full.m be a wrapper. All the 
 %  actual full models have been moved to sub-routines for clarity.
 % model_full.m - Modified from hcil_simTestbed.m
@@ -24,14 +26,14 @@
 %
 % OUTPUTS:
 % -Eout
+% -Efiber==varargout{1}
 %
-% modvar structure fields (4):
+% modvar structure fields for model_full:
 % -sbpIndex
 % -wpsbpIndex
 % -whichSource
-% -flagGenMat
 
-function [Eout, Efiber] = model_full(mp,modvar,varargin)
+function [Eout, varargout] = model_full(mp,modvar,varargin)
 
 % Set default values of input parameters
 if(isfield(modvar,'sbpIndex'))
@@ -142,7 +144,12 @@ end
 %% Select which optical layout's full model to use.
 switch lower(mp.layout)
     case{'fourier'}
-        [Eout, Efiber] = model_full_Fourier(mp, lambda, Ein, normFac);
+        if(mp.flagFiber)
+            [Eout, Efiber] = model_full_Fourier(mp, lambda, Ein, normFac);
+            varargout{1} = Efiber;
+        else
+            Eout = model_full_Fourier(mp, lambda, Ein, normFac);
+        end
         
     case{'wfirst_phaseb_simple'} %--Use compact model as the full model.
                 

--- a/models/model_full_Fourier.m
+++ b/models/model_full_Fourier.m
@@ -25,9 +25,13 @@
 %
 % OUTPUTS:
 % - Eout = 2-D electric field at final plane of optical layout
+% - varargout{1}==Efiber = E-field at final plane when a single mode fiber
+% is used
 %
 % REVISION HISTORY:
 % --------------
+% Modified on 2019-04-18 by A.J. Riggs to use varargout for Efiber instead
+% of having Efiber as a required output. 
 % Modified on 2019-04-05 by A.J. Riggs to have the normalization be
 %   computed by moving the source off-axis instead of removing the FPM.
 % Modified on 2019-02-14 by G. Ruane to handle scalar vortex FPMs
@@ -39,7 +43,7 @@
 % Modified on 2015-02-18 by A.J. Riggs from hcil_model.m to hcil_simTestbed.m to include
 %  extra errors in the model to simulate the actual testbed for fake images.
 
-function [Eout, Efiber] = model_full_Fourier(mp, lambda, Ein, normFac)
+function [Eout, varargout] = model_full_Fourier(mp, lambda, Ein, normFac)
 
 mirrorFac = 2; % Phase change is twice the DM surface height.
 NdmPad = mp.full.NdmPad;
@@ -248,8 +252,6 @@ if(isfield(mp,'flagElyot'))
     Eout = EP40;
 end
 
-Efiber = 0;
-
 if(mp.flagFiber)
     Efiber = cell(mp.Fend.Nlens,1);
     
@@ -261,6 +263,15 @@ if(mp.flagFiber)
     end
 
     Efiber = permute(reshape(cell2mat(Efiber)', mp.F5.Nxi, mp.F5.Neta, mp.Fend.Nlens), [2,1,3]);
+    varargout{1} = Efiber;
 end
+
+% function [s,varargout] = returnVariableNumOutputs(x)
+%     nout = max(nargout,1) - 1;
+%     s = size(x);
+%     for k = 1:nout
+%         varargout{k} = s(k);
+%     end
+% end
 
 end %--END OF FUNCTION


### PR DESCRIPTION
- Fixed a bug in the software mask generation that caused a line to appear through an annular region.
- Improved the syntax for the fiber cases to use varargout for the optional output of the E-field from the fiber.