### PR TITLE
v3.2.2 Changes to falco_gen_SW_mask. Major bug fix for model-based EFC grid search.

### DIFF
--- a/config/EXAMPLE_defaults_WFIRST_PhaseB_SPC_Spec_simple.m
+++ b/config/EXAMPLE_defaults_WFIRST_PhaseB_SPC_Spec_simple.m
@@ -4,7 +4,7 @@
 %% Misc
 
 %--Record Keeping
-mp.SeriesNum = 45;
+mp.SeriesNum = 1;
 mp.TrialNum = 1;
 
 %--Special Computational Settings
@@ -19,7 +19,7 @@ mp.centering = 'pixel';
 mp.planetFlag = false;
 
 %--Method of computing core throughput:
-% - 'HMI' for energy within half-max isophote divided by energy at telescope pupil
+% - 'HMI' for energy within half-max isophote(s) divided by energy at telescope pupil
 % - 'EE' for encircled energy within a radius (mp.thput_radius) divided by energy at telescope pupil
 mp.thput_metric = 'HMI'; 
 mp.thput_radius = 0.7; %--photometric aperture radius [lambda_c/D]. Used ONLY for 'EE' method.
@@ -56,17 +56,18 @@ mp.est.probe.axis = 'alternate';     % which axis to have the phase discontinuit
 mp.est.probe.gainFudge = 1;     % empirical fudge factor to make average probe amplitude match desired value.
 
 %--New variables for pairwise probing with a Kalman filter
-%  mp.est.ItrStartKF =  %Which correction iteration to start recursive estimate
-%  mp.est.tExp =
-%  mp.est.num_im =
-%  mp.readNoiseStd =
-%  mp.peakCountsPerPixPerSec =
-%  mp.est.Qcoef =
-%  mp.est.Rcoef =
+% mp.est.ItrStartKF = 2 %Which correction iteration to start recursive estimate
+% mp.est.tExp =
+% mp.est.num_im =
+% mp.readNoiseStd =
+% mp.peakCountsPerPixPerSec =
+% mp.est.Qcoef =
+% mp.est.Rcoef =
+% mp.est.Pcoef0 = 
 
 %% Wavefront Control: General
 
-mp.ctrl.flagUseModel = true; %--Whether to perform a model-based (vs empirical) grid search for the controller
+mp.ctrl.flagUseModel = true; %--Use the compact model for the grid search
 
 %--Threshold for culling weak actuators from the Jacobian:
 mp.logGmin = -6;  % 10^(mp.logGmin) used on the intensity of DM1 and DM2 Jacobians to weed out the weakest actuators
@@ -76,12 +77,12 @@ mp.jac.zerns = 1;  %--Which Zernike modes to include in Jacobian. Given as the m
 mp.jac.Zcoef = 1e-9*[1]; %1e-9*ones(size(mp.jac.zerns)); %--meters RMS of Zernike aberrations. (piston value is not used; it is a placeholder for correct indexing of other modes.)
     
 %--Zernikes to compute sensitivities for
-mp.eval.indsZnoll = [];%2:3;%2:6; %--Noll indices of Zernikes to compute values for
+mp.eval.indsZnoll = 2:6; %--Noll indices of Zernikes to compute values for
 %--Annuli to compute 1nm RMS Zernike sensitivities over. Columns are [inner radius, outer radius]. One row per annulus.
-mp.eval.Rsens = [];%...
-%                 [3., 4.;...
-%                 4., 8.;
-%                 8., 9.];  
+mp.eval.Rsens = [3., 4.;
+                4., 5.;
+                5., 8.;
+                8., 9.];  
 
 %--Grid- or Line-Search Settings
 mp.ctrl.log10regVec = -6:1/2:-2; %--log10 of the regularization exponents (often called Beta values)
@@ -105,41 +106,37 @@ mp.maxAbsdV = 1000;     %--Max +/- delta voltage step for each actuator for DMs 
 %  - 'gridsearchEFC' for EFC as an empirical grid search over tuning parameters
 %  - 'plannedEFC' for EFC with an automated regularization schedule
 %  - 'SM-CVX' for constrained EFC using CVX. --> DEVELOPMENT ONLY
-mp.controller = 'plannedEFC';
 
-% % % % GRID SEARCH EFC DEFAULTS     
-% %--WFSC Iterations and Control Matrix Relinearization
-% mp.Nitr = 5; %--Number of estimation+control iterations to perform
-% mp.relinItrVec = 1:mp.Nitr;  %--Which correction iterations at which to re-compute the control Jacobian
-% mp.dm_ind = [1 2]; %--Which DMs to use
+% % % GRID SEARCH EFC DEFAULTS     
+%--WFSC Iterations and Control Matrix Relinearization
+mp.controller = 'gridsearchEFC';
+mp.Nitr = 5; %--Number of estimation+control iterations to perform
+mp.relinItrVec = 1:mp.Nitr;  %--Which correction iterations at which to re-compute the control Jacobian
+mp.dm_ind = [1 2]; %--Which DMs to use
 
-% % PLANNED SEARCH EFC DEFAULTS     
-mp.dm_ind = [1 2 ]; % vector of DMs used in controller at ANY time (not necessarily all at once or all the time). 
-mp.ctrl.dmfacVec = 1;
-%--CONTROL SCHEDULE. Columns of mp.ctrl.sched_mat are: 
-    % Column 1: # of iterations, 
-    % Column 2: log10(regularization), 
-    % Column 3: which DMs to use (12, 128, 129, or 1289) for control
-    % Column 4: flag (0 = false, 1 = true), whether to re-linearize
-    %   at that iteration.
-    % Column 5: flag (0 = false, 1 = true), whether to perform an
-    %   EFC parameter grid search to find the set giving the best
-    %   contrast .
-    % The imaginary part of the log10(regularization) in column 2 is
-    %  replaced for that iteration with the optimal log10(regularization)
-    % A row starting with [0, 0, 0, 1...] is for relinearizing only at that time
-
-mp.ctrl.sched_mat = [...
-    [0,0,0,1,0];
-    repmat([1,1j,12,0,1],[10,1]);...
-    ];
-
+% % % PLANNED SEARCH EFC DEFAULTS  
+% mp.controller = 'plannedEFC';
+% mp.dm_ind = [1 2 ]; % vector of DMs used in controller at ANY time (not necessarily all at once or all the time). 
+% mp.ctrl.dmfacVec = 1;
+% %--CONTROL SCHEDULE. Columns of mp.ctrl.sched_mat are: 
+%     % Column 1: # of iterations, 
+%     % Column 2: log10(regularization), 
+%     % Column 3: which DMs to use (12, 128, 129, or 1289) for control
+%     % Column 4: flag (0 = false, 1 = true), whether to re-linearize
+%     %   at that iteration.
+%     % Column 5: flag (0 = false, 1 = true), whether to perform an
+%     %   EFC parameter grid search to find the set giving the best
+%     %   contrast .
+%     % The imaginary part of the log10(regularization) in column 2 is
+%     %  replaced for that iteration with the optimal log10(regularization)
+%     % A row starting with [0, 0, 0, 1...] is for relinearizing only at that time
+% 
 % mp.ctrl.sched_mat = [...
 %     repmat([1,1j,12,1,1],[4,1]);...
 %     repmat([1,1j-1,12,1,1],[25,1]);...
 %     repmat([1,1j,12,1,1],[1,1]);...
 %     ];
-[mp.Nitr, mp.relinItrVec, mp.gridSearchItrVec, mp.ctrl.log10regSchedIn, mp.dm_ind_sched] = falco_ctrl_EFC_schedule_generator(mp.ctrl.sched_mat);
+% [mp.Nitr, mp.relinItrVec, mp.gridSearchItrVec, mp.ctrl.log10regSchedIn, mp.dm_ind_sched] = falco_ctrl_EFC_schedule_generator(mp.ctrl.sched_mat);
 
 
 %% Deformable Mirrors: Influence Functions
@@ -163,20 +160,20 @@ mp.dm2.inf_sign = '+';
 mp.dm1.Nact = 48;               % # of actuators across DM array
 mp.dm1.VtoH = 1e-9*ones(48);  % gains of all actuators [nm/V of free stroke]
 mp.dm1.xtilt = 0;               % for foreshortening. angle of rotation about x-axis [degrees]
-mp.dm1.ytilt = 5.7;               % for foreshortening. angle of rotation about y-axis [degrees]
+mp.dm1.ytilt = 5.83;               % for foreshortening. angle of rotation about y-axis [degrees]
 mp.dm1.zrot = 0;                % clocking of DM surface [degrees]
-mp.dm1.xc = 23.5;%(48/2 - 1/2);       % x-center location of DM surface [actuator widths]
-mp.dm1.yc = 23.5;%(48/2 - 1/2);       % y-center location of DM surface [actuator widths]
+mp.dm1.xc = (48/2 - 1/2);       % x-center location of DM surface [actuator widths]
+mp.dm1.yc = (48/2 - 1/2);       % y-center location of DM surface [actuator widths]
 mp.dm1.edgeBuffer = 1;          % max radius (in actuator spacings) outside of beam on DM surface to compute influence functions for. [actuator widths]
 
 %--DM2 parameters
 mp.dm2.Nact = 48;               % # of actuators across DM array
 mp.dm2.VtoH = 1e-9*ones(48);  % gains of all actuators [nm/V of free stroke]
 mp.dm2.xtilt = 0;               % for foreshortening. angle of rotation about x-axis [degrees]
-mp.dm2.ytilt = 5.7;%               % for foreshortening. angle of rotation about y-axis [degrees]
+mp.dm2.ytilt = 5.55;%8;               % for foreshortening. angle of rotation about y-axis [degrees]
 mp.dm2.zrot = 0;              % clocking of DM surface [degrees]
-mp.dm2.xc = 23.5;%(48/2 - 1/2);       % x-center location of DM surface [actuator widths]
-mp.dm2.yc = 23.5;%(48/2 - 1/2);       % y-center location of DM surface [actuator widths]
+mp.dm2.xc = (48/2 - 1/2);       % x-center location of DM surface [actuator widths]
+mp.dm2.yc = (48/2 - 1/2);       % y-center location of DM surface [actuator widths]
 mp.dm2.edgeBuffer = 1;          % max radius (in actuator spacings) outside of beam on DM surface to compute influence functions for. [actuator widths]
 
 %--Aperture stops at DMs
@@ -194,13 +191,12 @@ mp.d_dm1_dm2 = 1.000;   % distance between DM1 and DM2 [meters]
 
 %--Key Optical Layout Choices
 mp.flagSim = true;      %--Simulation or not
-mp.layout = 'wfirst_phaseb_proper';  %--Which optical layout to use
+mp.layout = 'Fourier';  %--Which optical layout to use
 mp.coro = 'SPLC';
 mp.flagApod = true;    %--Whether to use an apodizer or not
-mp.flagDMwfe = false;  %--Whether to use BMC DM quilting maps
 
 %--Final Focal Plane Properties
-mp.Fend.res = 3;%(730/660)*2.; %--Sampling [ pixels per lambda0/D]
+mp.Fend.res = 6;%(730/660)*2.; %--Sampling [ pixels per lambda0/D]
 mp.Fend.FOV = 11.; %--half-width of the field of view in both dimensions [lambda0/D]
 
 %--Correction and scoring region definition
@@ -213,27 +209,28 @@ mp.Fend.score.Rout = 9;  % outer radius of dark hole scoring region [lambda0/D]
 mp.Fend.score.ang = 65;  % angular opening of dark hole scoring region [degrees]
 
 mp.Fend.sides = 'both'; %--Which side(s) for correction: 'both', 'left', 'right', 'top', 'bottom'
+mp.Fend.clockAngDeg = 90; %--Amount to rotate the dark hole location
 
 %% Optical Layout: Compact Model (and Jacobian Model)
+% NOTE for HLC and LC: Lyot plane resolution must be the same as input pupil's in order to use Babinet's principle
 
 %--Focal Lengths
 mp.fl = 1.; %--[meters] Focal length value used for all FTs in the compact model. Don't need different values since this is a Fourier model.
 
 %--Pupil Plane Diameters
-mp.P2.D = 46.3e-3; %46.2987e-3;
-mp.P3.D = 46.3e-3; %46.2987e-3;
-mp.P4.D = 46.3e-3; %46.2987e-3;
+mp.P2.D = 46.2987e-3;
+mp.P3.D = 46.2987e-3;
+mp.P4.D = 46.2987e-3;
 
 %--Pupil Plane Resolutions
-mp.P1.compact.Nbeam = 386;
-mp.P2.compact.Nbeam = 386;
-mp.P3.compact.Nbeam = 386;
+mp.P1.compact.Nbeam = 386;%1000;%386;
+mp.P2.compact.Nbeam = 386;%1000;%386;
+mp.P3.compact.Nbeam = 386;%1000;%386;
 mp.P4.compact.Nbeam = 60;
 
 %--Shaped Pupil Mask: Load and downsample.
-% mp.SPname = 'SPC-20190130';
+mp.SPname = 'SPC-20190130';
 SP0 = fitsread('SPM_SPC-20190130.fits');
-% % SP0(2:end,2:end) = rot90(SP0(2:end,2:end),2);
 
 if(mp.P1.compact.Nbeam==1000)
     mp.P3.compact.mask = SP0;
@@ -269,15 +266,13 @@ else
         otherwise
             mp.P3.compact.mask = SP1;
     end
-    
-    figure(2); imagesc(SP0); axis xy equal tight; colormap jet; colorbar; drawnow;
-    figure(3); imagesc(SP1); axis xy equal tight; colormap jet; colorbar; drawnow;
+    figure(2); imagesc(SP0); axis xy equal tight; colormap jet; colorbar;
+    figure(3); imagesc(SP1); axis xy equal tight; colormap jet; colorbar;
     % figure(12); imagesc(SP0-fliplr(SP0)); axis xy equal tight; colormap jet; colorbar;
     % figure(13); imagesc(SP1-fliplr(SP1)); axis xy equal tight; colormap jet; colorbar;
-
 end
 
-
+%%
 %--Number of re-imaging relays between pupil planesin compact model. Needed
 %to keep track of 180-degree rotations and (1/1j)^2 factors compared to the
 %full model, which probably has extra collimated beams compared to the
@@ -285,7 +280,7 @@ end
 mp.Nrelay1to2 = 1;
 mp.Nrelay2to3 = 1;
 mp.Nrelay3to4 = 1;
-mp.NrelayFend = 1; %--How many times to rotate the final image by 180 degrees
+mp.NrelayFend = 0; %--How many times to rotate the final image by 180 degrees
 
 %--FPM resolution
 mp.F3.compact.res = 6;    % sampling of FPM for compact model [pixels per lambda0/D]
@@ -329,99 +324,59 @@ end
 
 %% Optical Layout: Full Model 
 
-mp.full.data_dir = '/Users/ajriggs/Repos/proper-models/wfirst_cgi/data_phaseb/'; % mask design data path
-mp.full.cor_type = 'spc-ifs_long'; %   'hlc', 'spc', or 'none' (none = clear aperture, no coronagraph)
+%--Focal Lengths
+% mp.fl = 1; 
 
-mp.full.flagGenFPM = false;
-mp.full.flagPROPER = true; %--Whether the full model is a PROPER prescription
-
-% %--Pupil Plane Resolutions
+%--Pupil Plane Resolutions
 mp.P1.full.Nbeam = 1000;
-mp.P1.full.Narr = 1002;
+mp.P2.full.Nbeam = 1000;
+mp.P3.full.Nbeam = 1000;
+mp.P4.full.Nbeam = 200;
 
-mp.full.output_dim = ceil_even(1 + mp.Fend.res*(2*mp.Fend.FOV)); %  dimensions of output in pixels (overrides output_dim0)
-mp.full.final_sampling_lam0 = 1/mp.Fend.res;	%   final sampling in lambda0/D
+%--Shaped Pupil Mask.
+mp.P3.full.mask = fitsread('SPM_SPC-20190130.fits');
+mp.SPname = 'SPC-20190130';
 
-mp.full.pol_conds = 10;% [-2,-1,1,2]; %--Which polarization states to use when creating an image.
-mp.full.polaxis = 10;                %   polarization condition (only used with input_field_rootname)
-mp.full.use_errors = true;
+%--FPM resolution
+mp.F3.full.res = 20;    % sampling of FPM for full model [pixels per lambda0/D]
 
-mp.full.zindex = 4;
-mp.full.zval_m = 0.19e-9;
-mp.full.use_hlc_dm_patterns = false; % whether to use design WFE maps for HLC
-mp.full.lambda0_m = mp.lambda0;
-mp.full.input_field_rootname = '';	%   rootname of files containing aberrated pupil
-mp.full.use_dm1 = 0;                %   use DM1? 1 or 0
-mp.full.use_dm2 = 0;                %   use DM2? 1 or 0
-mp.full.dm_sampling_m = 0.9906e-3;     %   actuator spacing in meters; default is 1 mm
-mp.full.dm1_xc_act = 23.5;          %   for 48x48 DM, wavefront centered at actuator intersections: (0,0) = 1st actuator center
-mp.full.dm1_yc_act = 23.5;
-mp.full.dm1_xtilt_deg = 0;   		%   tilt around X axis
-mp.full.dm1_ytilt_deg = 5.7;		%   effective DM tilt in deg including 9.65 deg actual tilt and pupil ellipticity
-mp.full.dm1_ztilt_deg = 0;
-mp.full.dm2_xc_act = 23.5;		
-mp.full.dm2_yc_act = 23.5;
-mp.full.dm2_xtilt_deg = 0;   
-mp.full.dm2_ytilt_deg = 5.7;
-mp.full.dm2_ztilt_deg = 0;
-mp.full.use_fpm  = 1;
-mp.full.fpm_axis = 'p';             %   HLC FPM axis: '', 's', 'p'
+%--Load and downsample the FPM. To get good grayscale edges, convolve with the correct window before downsampling. 
+FPM0 = fitsread('FPM_res100_SPC-20190130.fits'); %--Resolution of 100 pixels per lambda0/D
+FPM0 = padOrCropOdd(FPM0,1821);
+% figure(1); imagesc(FPM0); axis xy equal tight; colormap jet; colorbar;
+dx0 = 1/100;
+dx1 = 1/mp.F3.full.res;
+N0 = size(FPM0,1);
+switch lower(mp.centering)
+    case{'pixel'}
+        N1 = ceil_odd(N0*dx0/dx1);
+    case{'interpixel'}
+        N1 = ceil_even(N0*dx0/dx1);
+end
+x0 = (-(N0-1)/2:(N0-1)/2)*dx0;
+[X0,Y0] = meshgrid(x0);
+R0 = sqrt(X0.^2+Y0.^2);
+Window = 0*R0;
+Window(R0<=dx1/2) = 1; Window = Window/sum(sum(Window));
+% figure(10); imagesc(Window); axis xy equal tight; colormap jet; colorbar;
+FPM0 = ifftshift(  ifft2( fft2(fftshift(Window)).*fft2(fftshift(FPM0)) )); %--To get good grayscale edges, convolve with the correct window before downsampling.
+FPM0 = circshift(FPM0,[1 1]); %--Undo a centering shift
+x1 = (-(N1-1)/2:(N1-1)/2)*dx1;
+[X1,Y1] = meshgrid(x1);
+FPM1 = interp2(X0,Y0,FPM0,X1,Y1,'cubic',0); %--Downsample by interpolation
+switch lower(mp.centering)
+    case{'pixel'}
+        mp.F3.full.mask.amp = zeros(N1+1,N1+1);
+        mp.F3.full.mask.amp(2:end,2:end) = FPM1;
+    otherwise
+        mp.F3.full.mask.amp = FPM1;
+end
 
-mp.full.dm1.flatmap = fitsread('errors_polaxis10_dm.fits');
-mp.full.dm2.flatmap = 0;
-
-
-
-% %--Pupil Plane Resolutions
-% mp.P1.full.Nbeam = 1000;
-% mp.P2.full.Nbeam = 1000;
-% mp.P3.full.Nbeam = 1000;
-% mp.P4.full.Nbeam = 200;
-
-% %--Shaped Pupil Mask.
-% mp.P3.full.mask = fitsread('SPM_SPC-20190130.fits');
-% mp.SPname = 'SPC-20190130';
-
-% %--FPM resolution
-% mp.F3.full.res = 20;    % sampling of FPM for full model [pixels per lambda0/D]
-% %--Load and downsample the FPM. To get good grayscale edges, convolve with the correct window before downsampling. 
-% FPM0 = fitsread('FPM_res100_SPC-20190130.fits'); %--Resolution of 100 pixels per lambda0/D
-% FPM0 = padOrCropOdd(FPM0,1821);
-% % figure(1); imagesc(FPM0); axis xy equal tight; colormap jet; colorbar;
-% dx0 = 1/100;
-% dx1 = 1/mp.F3.full.res;
-% N0 = size(FPM0,1);
-% switch lower(mp.centering)
-%     case{'pixel'}
-%         N1 = ceil_odd(N0*dx0/dx1);
-%     case{'interpixel'}
-%         N1 = ceil_even(N0*dx0/dx1);
-% end
-% x0 = (-(N0-1)/2:(N0-1)/2)*dx0;
-% [X0,Y0] = meshgrid(x0);
-% R0 = sqrt(X0.^2+Y0.^2);
-% Window = 0*R0;
-% Window(R0<=dx1/2) = 1; Window = Window/sum(sum(Window));
-% % figure(10); imagesc(Window); axis xy equal tight; colormap jet; colorbar;
-% FPM0 = ifftshift(  ifft2( fft2(fftshift(Window)).*fft2(fftshift(FPM0)) )); %--To get good grayscale edges, convolve with the correct window before downsampling.
-% FPM0 = circshift(FPM0,[1 1]); %--Undo a centering shift
-% x1 = (-(N1-1)/2:(N1-1)/2)*dx1;
-% [X1,Y1] = meshgrid(x1);
-% FPM1 = interp2(X0,Y0,FPM0,X1,Y1,'cubic',0); %--Downsample by interpolation
-% switch lower(mp.centering)
-%     case{'pixel'}
-%         mp.F3.full.mask.amp = zeros(N1+1,N1+1);
-%         mp.F3.full.mask.amp(2:end,2:end) = FPM1;
-%     otherwise
-%         mp.F3.full.mask.amp = FPM1;
-% end
-% % figure(2); imagesc(FPM0); axis xy equal tight; colormap jet; colorbar;
-% % figure(3); imagesc(FPM1); axis xy equal tight; colormap jet; colorbar;
+% figure(2); imagesc(FPM0); axis xy equal tight; colormap jet; colorbar;
+% figure(3); imagesc(FPM1); axis xy equal tight; colormap jet; colorbar;
 
 
 %% Mask Definitions
-
-mp.compact.flagGenFPM = false;
 
 %--Pupil definition
 mp.whichPupil = 'WFIRST180718';
@@ -436,8 +391,11 @@ mp.P4.ODnorm = 0.92; %--Lyot stop OD [Dtelescope]
 mp.P4.ang = 90;      %--Lyot stop opening angle [degrees]
 mp.P4.wStrut = 0;    %--Lyot stop strut width [pupil diameters]
 
-% %--FPM size
-% mp.F3.Rin = 2.6;   % inner hard-edge radius of the focal plane mask [lambda0/D]. Needs to be <= mp.F3.Rin 
-% mp.F3.Rout = 9;   % radius of outer opaque edge of FPM [lambda0/D]
-% mp.F3.ang = 65;    % on each side, opening angle [degrees]
+%--FPM size
+mp.F3.Rin = 2.6;   % inner hard-edge radius of the focal plane mask [lambda0/D]. Needs to be <= mp.F3.Rin 
+mp.F3.Rout = 9;   % radius of outer opaque edge of FPM [lambda0/D]
+mp.F3.ang = 65;    % on each side, opening angle [degrees]
+
+
+%% LC-Specific Values %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/lib/masks/falco_gen_SW_mask.m
+++ b/lib/masks/falco_gen_SW_mask.m
@@ -118,8 +118,10 @@ elseif( strcmpi(whichSide,'T') || strcmpi(whichSide,'top') )
     clockAng = 0;
 elseif( strcmpi(whichSide,'B') || strcmpi(whichSide,'bottom') )
     clockAng = pi;   
+elseif( strcmpi(whichSide,'both') )
+    clockAng = 0;
 else
-    error('falco_gen_SW_mask.m: Unknown value specified for inputs.clockAng')
+    error('falco_gen_SW_mask.m: Unknown value specified for inputs.whichSide')
 end
 
 clockAng = clockAng + inputs.clockAngDeg*pi/180; %--Add extra clocking specified by inputs.clockAngDeg

--- a/lib/masks/falco_gen_SW_mask.m
+++ b/lib/masks/falco_gen_SW_mask.m
@@ -54,6 +54,9 @@ else
     DHshape = 'circle'; %--Default to a circular outer edge
 end
 
+if(~isfield(inputs,'clockAngDeg'));  inputs.clockAngDeg = 0;  end %--Amount extra to clock the dark hole
+
+
 xi_cen = 0;
 eta_cen = 0;
 
@@ -107,28 +110,24 @@ switch lower(DHshape)
         maskSW0 = (RHO>=rhoInner & RHO<=rhoOuter);
 end
 
-%--If the use doesn't pass the clocking angle 
-if(~isfield(inputs,'clockAngDeg'))
-    if( strcmpi(whichSide,'L') || strcmpi(whichSide,'left') )
-        clockAng = pi;
-    elseif( strcmpi(whichSide,'R') || strcmpi(whichSide,'right') )
-        clockAng = 0;
-    elseif( strcmpi(whichSide,'T') || strcmpi(whichSide,'top') )
-        clockAng = pi/2;
-    elseif( strcmpi(whichSide,'B') || strcmpi(whichSide,'bottom') )
-        clockAng = 3*pi/2;   
-    else
-        clockAng = 0;
-    end
+if( strcmpi(whichSide,'L') || strcmpi(whichSide,'left') )
+    clockAng = 3*pi/2;
+elseif( strcmpi(whichSide,'R') || strcmpi(whichSide,'right') )
+    clockAng = pi/2;
+elseif( strcmpi(whichSide,'T') || strcmpi(whichSide,'top') )
+    clockAng = 0;
+elseif( strcmpi(whichSide,'B') || strcmpi(whichSide,'bottom') )
+    clockAng = pi;   
 else
-    clockAng = inputs.clockAngDeg*pi/180;
+    error('falco_gen_SW_mask.m: Unknown value specified for inputs.clockAng')
 end
+
+clockAng = clockAng + inputs.clockAngDeg*pi/180; %--Add extra clocking specified by inputs.clockAngDeg
 
 maskSW = maskSW0 & abs(angle(exp(1i*(THETA-clockAng))))<=angRad/2;
 
 if(strcmpi(whichSide,'both'))
-    clockAng = clockAng + pi;
-    maskSW2 = maskSW0 & abs(angle(exp(1i*(THETA-clockAng))))<=angRad/2;
+    maskSW2 = maskSW0 & abs(angle(exp(1i*(THETA-(clockAng+pi)))))<=angRad/2;
     maskSW = or(maskSW,maskSW2);
 end
 

--- a/lib/masks/falco_gen_bowtie_LS.m
+++ b/lib/masks/falco_gen_bowtie_LS.m
@@ -57,9 +57,9 @@ if(isfield(inputs,'clocking')); clocking = inputs.clocking; end
 if(isfield(inputs,'magfac')); magfac = inputs.magfac; end
 
 if(strcmpi(centering,'pixel'))
-    Narray = ceil_even(magfac*Nbeam+1 + 2*max(Nbeam*[xShear,yShear])); %--number of points across output array. Sometimes requires two more pixels when pixel centered.
+    Narray = ceil_even(magfac*Nbeam+1 + 2*max(Nbeam*abs([xShear,yShear]))); %--number of points across output array. Sometimes requires two more pixels when pixel centered.
 else
-    Narray = ceil_even(magfac*Nbeam + 2*max(Nbeam*[xShear,yShear])); %--number of points across output array. Same size as width when interpixel centered.
+    Narray = ceil_even(magfac*Nbeam + 2*max(Nbeam*abs([xShear,yShear]))); %--number of points across output array. Same size as width when interpixel centered.
 end
 
 Darray = Narray*dx; %--width of the output array (meters)

--- a/lib/plot/falco_plot_progress.m
+++ b/lib/plot/falco_plot_progress.m
@@ -4,7 +4,7 @@
 % at the California Institute of Technology.
 % -------------------------------------------------------------------------
 %
-function handles = falco_plot_progress(handles,mp,Itr,contrast_bandavg,Im,DM1surf,DM2surf,ImSimOffaxis)
+function handles = falco_plot_progress(handles,mp,Itr,InormHist,Im,DM1surf,DM2surf,ImSimOffaxis)
 
 Im(Im<0) = 0; %--Prevent the log10(Im) plot from getting complex values.
 
@@ -53,7 +53,7 @@ if(mp.flagPlot)
             ylabel('$\lambda_0$/D','FontSize',16,'Interpreter','LaTeX');
             set(gca,'FontSize',20,'FontName','Times','FontWeight','Normal')
             %ylabel(ch_psf,'$log_{10}$(NI)','Fontsize',24,'Interpreter','LaTex');
-            title(sprintf('Stellar PSF: NI = %.2e',contrast_bandavg(Itr)),'Fontsize',fst);%,'Fontweight','Bold');
+            title(sprintf('Stellar PSF: NI = %.2e',InormHist(Itr)),'Fontsize',fst);%,'Fontweight','Bold');
 
             %--Off-axis PSF
             h_offaxis = subplot(2,3,4); % Save the handle of the subplot
@@ -153,7 +153,7 @@ if(mp.flagPlot)
             ylabel('$\lambda_0$/D','FontSize',16,'Interpreter','LaTeX');
             set(gca,'FontSize',20,'FontName','Times','FontWeight','Normal')
             %ylabel(ch_psf,'$log_{10}$(NI)','Fontsize',24,'Interpreter','LaTex');
-            title(sprintf('Stellar PSF: NI = %.2e',contrast_bandavg(Itr)),'Fontsize',fst);%,'Fontweight','Bold');
+            title(sprintf('Stellar PSF: NI = %.2e',InormHist(Itr)),'Fontsize',fst);%,'Fontweight','Bold');
 
             h_offaxis = subplot(2,2,3); % Save the handle of the subplot
             set(h_offaxis, 'OuterPosition', [0.05, 0.02, [1 1]*0.45])

--- a/lib/wfsc/falco_ctrl_wrapup.m
+++ b/lib/wfsc/falco_ctrl_wrapup.m
@@ -62,6 +62,16 @@ if(any(mp.dm_ind==9))
     end
 end
 
+if(any(mp.dm_ind==1));  mp.dm1.dV = dDM.dDM1V;  end % Store the delta DM command
+if(any(mp.dm_ind==2));  mp.dm2.dV = dDM.dDM2V;  end % Store the delta DM command
+if(any(mp.dm_ind==3));  mp.dm3.dV = dDM.dDM3V;  end % Store the delta DM command
+if(any(mp.dm_ind==4));  mp.dm4.dV = dDM.dDM4V;  end % Store the delta DM command
+if(any(mp.dm_ind==5));  mp.dm5.dV = dDM.dDM5V;  end % Store the delta DM command
+if(any(mp.dm_ind==6));  mp.dm6.dV = dDM.dDM6V;  end % Store the delta DM command
+if(any(mp.dm_ind==7));  mp.dm7.dV = dDM.dDM7V;  end % Store the delta DM command
+if(any(mp.dm_ind==8));  mp.dm8.dV = dDM.dDM8V;  end % Store the delta DM command
+if(any(mp.dm_ind==9));  mp.dm9.dV = dDM.dDM9V;  end % Store the delta DM command
+
 %--Combine the delta command with the previous command
 if(any(mp.dm_ind==1));  mp.dm1.V = cvar.DM1Vnom + dDM.dDM1V;  end
 if(any(mp.dm_ind==2));  mp.dm2.V = cvar.DM2Vnom + dDM.dDM2V;  end

--- a/main/EXAMPLE_main_WFIRST_SPC_Spec_simple.m
+++ b/main/EXAMPLE_main_WFIRST_SPC_Spec_simple.m
@@ -4,7 +4,7 @@
 % at the California Institute of Technology.
 % -------------------------------------------------------------------------
 %
-%--Script to perform wavefront control with the WFIRST CGI Phase B SP(L)C-IFS design.
+%--Script to perform wavefront control with the WFIRST CGI Phase B SP(L)C-Spectroscopy design.
 %  1) Load the default model parameters for an SPLC.
 %  2) Specify the values to overwrite.
 %  3) Run a single trial of WFC using FALCO.
@@ -34,7 +34,7 @@ addpath(genpath(mp.path.proper)) %--Add PROPER library to MATLAB path
 
 %% Step 2: Load default model parameters
 
-EXAMPLE_defaults_WFIRST_PhaseB_SPC_IFS_simple
+EXAMPLE_defaults_WFIRST_PhaseB_SPC_Spec_simple
 
 %% Step 3: Overwrite default values as desired
 
@@ -54,11 +54,11 @@ mp.TrialNum = 1;
 % mp.dm2.V = temp.out.DM2V;
 % clear temp
 
-% %--DEBUGGING:
-% mp.fracBW = 0.01;       %--fractional bandwidth of the whole bandpass (Delta lambda / lambda0)
-% mp.Nsbp = 1;            %--Number of sub-bandpasses to divide the whole bandpass into for estimation and control
-% mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image in each sub-bandpass
-% mp.flagParfor = false; %--whether to use parfor for Jacobian calculation
+%--DEBUGGING:
+mp.fracBW = 0.01;       %--fractional bandwidth of the whole bandpass (Delta lambda / lambda0)
+mp.Nsbp = 1;            %--Number of sub-bandpasses to divide the whole bandpass into for estimation and control
+mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image in each sub-bandpass
+mp.flagParfor = false; %--whether to use parfor for Jacobian calculation
 
 % % % GRID-SEARCH EFC     
 mp.Nitr = 5; %--Number of estimation+control iterations to perform

--- a/setup/falco_init_ws.m
+++ b/setup/falco_init_ws.m
@@ -368,6 +368,7 @@ maskCorr.centering = mp.centering;
 maskCorr.FOV = mp.Fend.FOV;
 maskCorr.whichSide = mp.Fend.sides; %--which (sides) of the dark hole have open
 if(isfield(mp.Fend,'shape'));  maskCorr.shape = mp.Fend.shape;  end
+if(isfield(mp.Fend,'clockAngDeg'));  maskCorr.clockAngDeg = mp.Fend.clockAngDeg;  end
 
 %--Compact Model: Generate Software Mask for Correction 
 [mp.Fend.corr.mask, mp.Fend.xisDL, mp.Fend.etasDL] = falco_gen_SW_mask(maskCorr); 
@@ -379,7 +380,6 @@ mp.Fend.Neta = size(mp.Fend.corr.mask,1);
 
 [XIS,ETAS] = meshgrid(mp.Fend.xisDL, mp.Fend.etasDL);
 mp.Fend.RHOS = sqrt(XIS.^2 + ETAS.^2);
-
 % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 if(mp.flagFiber)
@@ -507,6 +507,8 @@ maskScore.centering = mp.centering;
 maskScore.FOV = mp.Fend.FOV; %--Determines max dimension length
 maskScore.whichSide = mp.Fend.sides; %--which (sides) of the dark hole have open
 if(isfield(mp.Fend,'shape'));  maskScore.shape = mp.Fend.shape;  end
+if(isfield(mp.Fend,'clockAngDeg'));  maskScore.clockAngDeg = mp.Fend.clockAngDeg;  end
+
 %--Compact Model: Generate Software Mask for Scoring Contrast 
 maskScore.Nxi = mp.Fend.Nxi; %--Set min dimension length to be same as for corr 
 maskScore.pixresFP = mp.Fend.res;

--- a/wfirst_modeling/EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_Spec.m
+++ b/wfirst_modeling/EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_Spec.m
@@ -4,7 +4,7 @@
 %% Misc
 
 %--Record Keeping
-mp.SeriesNum = 1;
+mp.SeriesNum = 45;
 mp.TrialNum = 1;
 
 %--Special Computational Settings
@@ -19,7 +19,7 @@ mp.centering = 'pixel';
 mp.planetFlag = false;
 
 %--Method of computing core throughput:
-% - 'HMI' for energy within half-max isophote(s) divided by energy at telescope pupil
+% - 'HMI' for energy within half-max isophote divided by energy at telescope pupil
 % - 'EE' for encircled energy within a radius (mp.thput_radius) divided by energy at telescope pupil
 mp.thput_metric = 'HMI'; 
 mp.thput_radius = 0.7; %--photometric aperture radius [lambda_c/D]. Used ONLY for 'EE' method.
@@ -56,18 +56,17 @@ mp.est.probe.axis = 'alternate';     % which axis to have the phase discontinuit
 mp.est.probe.gainFudge = 1;     % empirical fudge factor to make average probe amplitude match desired value.
 
 %--New variables for pairwise probing with a Kalman filter
-% mp.est.ItrStartKF = 2 %Which correction iteration to start recursive estimate
-% mp.est.tExp =
-% mp.est.num_im =
-% mp.readNoiseStd =
-% mp.peakCountsPerPixPerSec =
-% mp.est.Qcoef =
-% mp.est.Rcoef =
-% mp.est.Pcoef0 = 
+%  mp.est.ItrStartKF =  %Which correction iteration to start recursive estimate
+%  mp.est.tExp =
+%  mp.est.num_im =
+%  mp.readNoiseStd =
+%  mp.peakCountsPerPixPerSec =
+%  mp.est.Qcoef =
+%  mp.est.Rcoef =
 
 %% Wavefront Control: General
 
-mp.ctrl.flagUseModel = true; %--Use the compact model for the grid search
+mp.ctrl.flagUseModel = true; %--Whether to perform a model-based (vs empirical) grid search for the controller
 
 %--Threshold for culling weak actuators from the Jacobian:
 mp.logGmin = -6;  % 10^(mp.logGmin) used on the intensity of DM1 and DM2 Jacobians to weed out the weakest actuators
@@ -77,12 +76,12 @@ mp.jac.zerns = 1;  %--Which Zernike modes to include in Jacobian. Given as the m
 mp.jac.Zcoef = 1e-9*[1]; %1e-9*ones(size(mp.jac.zerns)); %--meters RMS of Zernike aberrations. (piston value is not used; it is a placeholder for correct indexing of other modes.)
     
 %--Zernikes to compute sensitivities for
-mp.eval.indsZnoll = 2:6; %--Noll indices of Zernikes to compute values for
+mp.eval.indsZnoll = [];%2:3;%2:6; %--Noll indices of Zernikes to compute values for
 %--Annuli to compute 1nm RMS Zernike sensitivities over. Columns are [inner radius, outer radius]. One row per annulus.
-mp.eval.Rsens = [3., 4.;
-                4., 5.;
-                5., 8.;
-                8., 9.];  
+mp.eval.Rsens = [];%...
+%                 [3., 4.;...
+%                 4., 8.;
+%                 8., 9.];  
 
 %--Grid- or Line-Search Settings
 mp.ctrl.log10regVec = -6:1/2:-2; %--log10 of the regularization exponents (often called Beta values)
@@ -106,37 +105,41 @@ mp.maxAbsdV = 1000;     %--Max +/- delta voltage step for each actuator for DMs 
 %  - 'gridsearchEFC' for EFC as an empirical grid search over tuning parameters
 %  - 'plannedEFC' for EFC with an automated regularization schedule
 %  - 'SM-CVX' for constrained EFC using CVX. --> DEVELOPMENT ONLY
+mp.controller = 'plannedEFC';
 
-% % % GRID SEARCH EFC DEFAULTS     
-%--WFSC Iterations and Control Matrix Relinearization
-mp.controller = 'gridsearchEFC';
-mp.Nitr = 5; %--Number of estimation+control iterations to perform
-mp.relinItrVec = 1:mp.Nitr;  %--Which correction iterations at which to re-compute the control Jacobian
-mp.dm_ind = [1 2]; %--Which DMs to use
+% % % % GRID SEARCH EFC DEFAULTS     
+% %--WFSC Iterations and Control Matrix Relinearization
+% mp.Nitr = 5; %--Number of estimation+control iterations to perform
+% mp.relinItrVec = 1:mp.Nitr;  %--Which correction iterations at which to re-compute the control Jacobian
+% mp.dm_ind = [1 2]; %--Which DMs to use
 
-% % % PLANNED SEARCH EFC DEFAULTS  
-% mp.controller = 'plannedEFC';
-% mp.dm_ind = [1 2 ]; % vector of DMs used in controller at ANY time (not necessarily all at once or all the time). 
-% mp.ctrl.dmfacVec = 1;
-% %--CONTROL SCHEDULE. Columns of mp.ctrl.sched_mat are: 
-%     % Column 1: # of iterations, 
-%     % Column 2: log10(regularization), 
-%     % Column 3: which DMs to use (12, 128, 129, or 1289) for control
-%     % Column 4: flag (0 = false, 1 = true), whether to re-linearize
-%     %   at that iteration.
-%     % Column 5: flag (0 = false, 1 = true), whether to perform an
-%     %   EFC parameter grid search to find the set giving the best
-%     %   contrast .
-%     % The imaginary part of the log10(regularization) in column 2 is
-%     %  replaced for that iteration with the optimal log10(regularization)
-%     % A row starting with [0, 0, 0, 1...] is for relinearizing only at that time
-% 
+% % PLANNED SEARCH EFC DEFAULTS     
+mp.dm_ind = [1 2 ]; % vector of DMs used in controller at ANY time (not necessarily all at once or all the time). 
+mp.ctrl.dmfacVec = 1;
+%--CONTROL SCHEDULE. Columns of mp.ctrl.sched_mat are: 
+    % Column 1: # of iterations, 
+    % Column 2: log10(regularization), 
+    % Column 3: which DMs to use (12, 128, 129, or 1289) for control
+    % Column 4: flag (0 = false, 1 = true), whether to re-linearize
+    %   at that iteration.
+    % Column 5: flag (0 = false, 1 = true), whether to perform an
+    %   EFC parameter grid search to find the set giving the best
+    %   contrast .
+    % The imaginary part of the log10(regularization) in column 2 is
+    %  replaced for that iteration with the optimal log10(regularization)
+    % A row starting with [0, 0, 0, 1...] is for relinearizing only at that time
+
+mp.ctrl.sched_mat = [...
+    [0,0,0,1,0];
+    repmat([1,1j,12,0,1],[10,1]);...
+    ];
+
 % mp.ctrl.sched_mat = [...
 %     repmat([1,1j,12,1,1],[4,1]);...
 %     repmat([1,1j-1,12,1,1],[25,1]);...
 %     repmat([1,1j,12,1,1],[1,1]);...
 %     ];
-% [mp.Nitr, mp.relinItrVec, mp.gridSearchItrVec, mp.ctrl.log10regSchedIn, mp.dm_ind_sched] = falco_ctrl_EFC_schedule_generator(mp.ctrl.sched_mat);
+[mp.Nitr, mp.relinItrVec, mp.gridSearchItrVec, mp.ctrl.log10regSchedIn, mp.dm_ind_sched] = falco_ctrl_EFC_schedule_generator(mp.ctrl.sched_mat);
 
 
 %% Deformable Mirrors: Influence Functions
@@ -160,20 +163,20 @@ mp.dm2.inf_sign = '+';
 mp.dm1.Nact = 48;               % # of actuators across DM array
 mp.dm1.VtoH = 1e-9*ones(48);  % gains of all actuators [nm/V of free stroke]
 mp.dm1.xtilt = 0;               % for foreshortening. angle of rotation about x-axis [degrees]
-mp.dm1.ytilt = 5.83;               % for foreshortening. angle of rotation about y-axis [degrees]
+mp.dm1.ytilt = 5.7;               % for foreshortening. angle of rotation about y-axis [degrees]
 mp.dm1.zrot = 0;                % clocking of DM surface [degrees]
-mp.dm1.xc = (48/2 - 1/2);       % x-center location of DM surface [actuator widths]
-mp.dm1.yc = (48/2 - 1/2);       % y-center location of DM surface [actuator widths]
+mp.dm1.xc = 23.5;%(48/2 - 1/2);       % x-center location of DM surface [actuator widths]
+mp.dm1.yc = 23.5;%(48/2 - 1/2);       % y-center location of DM surface [actuator widths]
 mp.dm1.edgeBuffer = 1;          % max radius (in actuator spacings) outside of beam on DM surface to compute influence functions for. [actuator widths]
 
 %--DM2 parameters
 mp.dm2.Nact = 48;               % # of actuators across DM array
 mp.dm2.VtoH = 1e-9*ones(48);  % gains of all actuators [nm/V of free stroke]
 mp.dm2.xtilt = 0;               % for foreshortening. angle of rotation about x-axis [degrees]
-mp.dm2.ytilt = 5.55;%8;               % for foreshortening. angle of rotation about y-axis [degrees]
+mp.dm2.ytilt = 5.7;%               % for foreshortening. angle of rotation about y-axis [degrees]
 mp.dm2.zrot = 0;              % clocking of DM surface [degrees]
-mp.dm2.xc = (48/2 - 1/2);       % x-center location of DM surface [actuator widths]
-mp.dm2.yc = (48/2 - 1/2);       % y-center location of DM surface [actuator widths]
+mp.dm2.xc = 23.5;%(48/2 - 1/2);       % x-center location of DM surface [actuator widths]
+mp.dm2.yc = 23.5;%(48/2 - 1/2);       % y-center location of DM surface [actuator widths]
 mp.dm2.edgeBuffer = 1;          % max radius (in actuator spacings) outside of beam on DM surface to compute influence functions for. [actuator widths]
 
 %--Aperture stops at DMs
@@ -191,12 +194,13 @@ mp.d_dm1_dm2 = 1.000;   % distance between DM1 and DM2 [meters]
 
 %--Key Optical Layout Choices
 mp.flagSim = true;      %--Simulation or not
-mp.layout = 'Fourier';  %--Which optical layout to use
+mp.layout = 'wfirst_phaseb_proper';  %--Which optical layout to use
 mp.coro = 'SPLC';
 mp.flagApod = true;    %--Whether to use an apodizer or not
+mp.flagDMwfe = false;  %--Whether to use BMC DM quilting maps
 
 %--Final Focal Plane Properties
-mp.Fend.res = 6;%(730/660)*2.; %--Sampling [ pixels per lambda0/D]
+mp.Fend.res = 3;%(730/660)*2.; %--Sampling [ pixels per lambda0/D]
 mp.Fend.FOV = 11.; %--half-width of the field of view in both dimensions [lambda0/D]
 
 %--Correction and scoring region definition
@@ -209,27 +213,28 @@ mp.Fend.score.Rout = 9;  % outer radius of dark hole scoring region [lambda0/D]
 mp.Fend.score.ang = 65;  % angular opening of dark hole scoring region [degrees]
 
 mp.Fend.sides = 'both'; %--Which side(s) for correction: 'both', 'left', 'right', 'top', 'bottom'
+mp.Fend.clockAngDeg = 90; %--Amount to rotate the dark hole location
 
 %% Optical Layout: Compact Model (and Jacobian Model)
-% NOTE for HLC and LC: Lyot plane resolution must be the same as input pupil's in order to use Babinet's principle
 
 %--Focal Lengths
 mp.fl = 1.; %--[meters] Focal length value used for all FTs in the compact model. Don't need different values since this is a Fourier model.
 
 %--Pupil Plane Diameters
-mp.P2.D = 46.2987e-3;
-mp.P3.D = 46.2987e-3;
-mp.P4.D = 46.2987e-3;
+mp.P2.D = 46.3e-3; %46.2987e-3;
+mp.P3.D = 46.3e-3; %46.2987e-3;
+mp.P4.D = 46.3e-3; %46.2987e-3;
 
 %--Pupil Plane Resolutions
-mp.P1.compact.Nbeam = 386;%1000;%386;
-mp.P2.compact.Nbeam = 386;%1000;%386;
-mp.P3.compact.Nbeam = 386;%1000;%386;
+mp.P1.compact.Nbeam = 386;
+mp.P2.compact.Nbeam = 386;
+mp.P3.compact.Nbeam = 386;
 mp.P4.compact.Nbeam = 60;
 
 %--Shaped Pupil Mask: Load and downsample.
-mp.SPname = 'SPC-20190130';
+% mp.SPname = 'SPC-20190130';
 SP0 = fitsread('SPM_SPC-20190130.fits');
+% % SP0(2:end,2:end) = rot90(SP0(2:end,2:end),2);
 
 if(mp.P1.compact.Nbeam==1000)
     mp.P3.compact.mask = SP0;
@@ -265,13 +270,15 @@ else
         otherwise
             mp.P3.compact.mask = SP1;
     end
-    figure(2); imagesc(SP0); axis xy equal tight; colormap jet; colorbar;
-    figure(3); imagesc(SP1); axis xy equal tight; colormap jet; colorbar;
+    
+    figure(2); imagesc(SP0); axis xy equal tight; colormap jet; colorbar; drawnow;
+    figure(3); imagesc(SP1); axis xy equal tight; colormap jet; colorbar; drawnow;
     % figure(12); imagesc(SP0-fliplr(SP0)); axis xy equal tight; colormap jet; colorbar;
     % figure(13); imagesc(SP1-fliplr(SP1)); axis xy equal tight; colormap jet; colorbar;
+
 end
 
-%%
+
 %--Number of re-imaging relays between pupil planesin compact model. Needed
 %to keep track of 180-degree rotations and (1/1j)^2 factors compared to the
 %full model, which probably has extra collimated beams compared to the
@@ -279,7 +286,7 @@ end
 mp.Nrelay1to2 = 1;
 mp.Nrelay2to3 = 1;
 mp.Nrelay3to4 = 1;
-mp.NrelayFend = 0; %--How many times to rotate the final image by 180 degrees
+mp.NrelayFend = 1; %--How many times to rotate the final image by 180 degrees
 
 %--FPM resolution
 mp.F3.compact.res = 6;    % sampling of FPM for compact model [pixels per lambda0/D]
@@ -323,59 +330,99 @@ end
 
 %% Optical Layout: Full Model 
 
-%--Focal Lengths
-% mp.fl = 1; 
+mp.full.data_dir = '/Users/ajriggs/Repos/proper-models/wfirst_cgi/data_phaseb/'; % mask design data path
+mp.full.cor_type = 'spc-spec_long'; %   'hlc', 'spc', or 'none' (none = clear aperture, no coronagraph)
 
-%--Pupil Plane Resolutions
+mp.full.flagGenFPM = false;
+mp.full.flagPROPER = true; %--Whether the full model is a PROPER prescription
+
+% %--Pupil Plane Resolutions
 mp.P1.full.Nbeam = 1000;
-mp.P2.full.Nbeam = 1000;
-mp.P3.full.Nbeam = 1000;
-mp.P4.full.Nbeam = 200;
+mp.P1.full.Narr = 1002;
 
-%--Shaped Pupil Mask.
-mp.P3.full.mask = fitsread('SPM_SPC-20190130.fits');
-mp.SPname = 'SPC-20190130';
+mp.full.output_dim = ceil_even(1 + mp.Fend.res*(2*mp.Fend.FOV)); %  dimensions of output in pixels (overrides output_dim0)
+mp.full.final_sampling_lam0 = 1/mp.Fend.res;	%   final sampling in lambda0/D
 
-%--FPM resolution
-mp.F3.full.res = 20;    % sampling of FPM for full model [pixels per lambda0/D]
+mp.full.pol_conds = 10;% [-2,-1,1,2]; %--Which polarization states to use when creating an image.
+mp.full.polaxis = 10;                %   polarization condition (only used with input_field_rootname)
+mp.full.use_errors = true;
 
-%--Load and downsample the FPM. To get good grayscale edges, convolve with the correct window before downsampling. 
-FPM0 = fitsread('FPM_res100_SPC-20190130.fits'); %--Resolution of 100 pixels per lambda0/D
-FPM0 = padOrCropOdd(FPM0,1821);
-% figure(1); imagesc(FPM0); axis xy equal tight; colormap jet; colorbar;
-dx0 = 1/100;
-dx1 = 1/mp.F3.full.res;
-N0 = size(FPM0,1);
-switch lower(mp.centering)
-    case{'pixel'}
-        N1 = ceil_odd(N0*dx0/dx1);
-    case{'interpixel'}
-        N1 = ceil_even(N0*dx0/dx1);
-end
-x0 = (-(N0-1)/2:(N0-1)/2)*dx0;
-[X0,Y0] = meshgrid(x0);
-R0 = sqrt(X0.^2+Y0.^2);
-Window = 0*R0;
-Window(R0<=dx1/2) = 1; Window = Window/sum(sum(Window));
-% figure(10); imagesc(Window); axis xy equal tight; colormap jet; colorbar;
-FPM0 = ifftshift(  ifft2( fft2(fftshift(Window)).*fft2(fftshift(FPM0)) )); %--To get good grayscale edges, convolve with the correct window before downsampling.
-FPM0 = circshift(FPM0,[1 1]); %--Undo a centering shift
-x1 = (-(N1-1)/2:(N1-1)/2)*dx1;
-[X1,Y1] = meshgrid(x1);
-FPM1 = interp2(X0,Y0,FPM0,X1,Y1,'cubic',0); %--Downsample by interpolation
-switch lower(mp.centering)
-    case{'pixel'}
-        mp.F3.full.mask.amp = zeros(N1+1,N1+1);
-        mp.F3.full.mask.amp(2:end,2:end) = FPM1;
-    otherwise
-        mp.F3.full.mask.amp = FPM1;
-end
+mp.full.zindex = 4;
+mp.full.zval_m = 0.19e-9;
+mp.full.use_hlc_dm_patterns = false; % whether to use design WFE maps for HLC
+mp.full.lambda0_m = mp.lambda0;
+mp.full.input_field_rootname = '';	%   rootname of files containing aberrated pupil
+mp.full.use_dm1 = 0;                %   use DM1? 1 or 0
+mp.full.use_dm2 = 0;                %   use DM2? 1 or 0
+mp.full.dm_sampling_m = 0.9906e-3;     %   actuator spacing in meters; default is 1 mm
+mp.full.dm1_xc_act = 23.5;          %   for 48x48 DM, wavefront centered at actuator intersections: (0,0) = 1st actuator center
+mp.full.dm1_yc_act = 23.5;
+mp.full.dm1_xtilt_deg = 0;   		%   tilt around X axis
+mp.full.dm1_ytilt_deg = 5.7;		%   effective DM tilt in deg including 9.65 deg actual tilt and pupil ellipticity
+mp.full.dm1_ztilt_deg = 0;
+mp.full.dm2_xc_act = 23.5;		
+mp.full.dm2_yc_act = 23.5;
+mp.full.dm2_xtilt_deg = 0;   
+mp.full.dm2_ytilt_deg = 5.7;
+mp.full.dm2_ztilt_deg = 0;
+mp.full.use_fpm  = 1;
+mp.full.fpm_axis = 'p';             %   HLC FPM axis: '', 's', 'p'
 
-% figure(2); imagesc(FPM0); axis xy equal tight; colormap jet; colorbar;
-% figure(3); imagesc(FPM1); axis xy equal tight; colormap jet; colorbar;
+mp.full.dm1.flatmap = fitsread('errors_polaxis10_dm.fits');
+mp.full.dm2.flatmap = 0;
+
+
+
+% %--Pupil Plane Resolutions
+% mp.P1.full.Nbeam = 1000;
+% mp.P2.full.Nbeam = 1000;
+% mp.P3.full.Nbeam = 1000;
+% mp.P4.full.Nbeam = 200;
+
+% %--Shaped Pupil Mask.
+% mp.P3.full.mask = fitsread('SPM_SPC-20190130.fits');
+% mp.SPname = 'SPC-20190130';
+
+% %--FPM resolution
+% mp.F3.full.res = 20;    % sampling of FPM for full model [pixels per lambda0/D]
+% %--Load and downsample the FPM. To get good grayscale edges, convolve with the correct window before downsampling. 
+% FPM0 = fitsread('FPM_res100_SPC-20190130.fits'); %--Resolution of 100 pixels per lambda0/D
+% FPM0 = padOrCropOdd(FPM0,1821);
+% % figure(1); imagesc(FPM0); axis xy equal tight; colormap jet; colorbar;
+% dx0 = 1/100;
+% dx1 = 1/mp.F3.full.res;
+% N0 = size(FPM0,1);
+% switch lower(mp.centering)
+%     case{'pixel'}
+%         N1 = ceil_odd(N0*dx0/dx1);
+%     case{'interpixel'}
+%         N1 = ceil_even(N0*dx0/dx1);
+% end
+% x0 = (-(N0-1)/2:(N0-1)/2)*dx0;
+% [X0,Y0] = meshgrid(x0);
+% R0 = sqrt(X0.^2+Y0.^2);
+% Window = 0*R0;
+% Window(R0<=dx1/2) = 1; Window = Window/sum(sum(Window));
+% % figure(10); imagesc(Window); axis xy equal tight; colormap jet; colorbar;
+% FPM0 = ifftshift(  ifft2( fft2(fftshift(Window)).*fft2(fftshift(FPM0)) )); %--To get good grayscale edges, convolve with the correct window before downsampling.
+% FPM0 = circshift(FPM0,[1 1]); %--Undo a centering shift
+% x1 = (-(N1-1)/2:(N1-1)/2)*dx1;
+% [X1,Y1] = meshgrid(x1);
+% FPM1 = interp2(X0,Y0,FPM0,X1,Y1,'cubic',0); %--Downsample by interpolation
+% switch lower(mp.centering)
+%     case{'pixel'}
+%         mp.F3.full.mask.amp = zeros(N1+1,N1+1);
+%         mp.F3.full.mask.amp(2:end,2:end) = FPM1;
+%     otherwise
+%         mp.F3.full.mask.amp = FPM1;
+% end
+% % figure(2); imagesc(FPM0); axis xy equal tight; colormap jet; colorbar;
+% % figure(3); imagesc(FPM1); axis xy equal tight; colormap jet; colorbar;
 
 
 %% Mask Definitions
+
+mp.compact.flagGenFPM = false;
 
 %--Pupil definition
 mp.whichPupil = 'WFIRST180718';
@@ -390,11 +437,8 @@ mp.P4.ODnorm = 0.92; %--Lyot stop OD [Dtelescope]
 mp.P4.ang = 90;      %--Lyot stop opening angle [degrees]
 mp.P4.wStrut = 0;    %--Lyot stop strut width [pupil diameters]
 
-%--FPM size
-mp.F3.Rin = 2.6;   % inner hard-edge radius of the focal plane mask [lambda0/D]. Needs to be <= mp.F3.Rin 
-mp.F3.Rout = 9;   % radius of outer opaque edge of FPM [lambda0/D]
-mp.F3.ang = 65;    % on each side, opening angle [degrees]
-
-
-%% LC-Specific Values %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% %--FPM size
+% mp.F3.Rin = 2.6;   % inner hard-edge radius of the focal plane mask [lambda0/D]. Needs to be <= mp.F3.Rin 
+% mp.F3.Rout = 9;   % radius of outer opaque edge of FPM [lambda0/D]
+% mp.F3.ang = 65;    % on each side, opening angle [degrees]
 

--- a/wfirst_modeling/EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_Spec_custom.m
+++ b/wfirst_modeling/EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_Spec_custom.m
@@ -216,11 +216,12 @@ mp.Fend.score.Rout = 9;  % outer radius of dark hole scoring region [lambda0/D]
 mp.Fend.score.ang = 65;  % angular opening of dark hole scoring region [degrees]
 
 mp.Fend.sides = 'both'; %--Which side(s) for correction: 'both', 'left', 'right', 'top', 'bottom'
+mp.Fend.clockAngDeg = 90; %--Amount to rotate the dark hole location
 
 %% Define custom SPC values.
 
 %--Full model mask files and resolutions
-file_dir = '/Users/ajriggs/Documents/Sim/cgi/wfirst_phaseb/spc_ifs_custom/';
+file_dir = '/Users/ajriggs/Documents/Sim/cgi/wfirst_phaseb/spc_spec_custom/';
 
 % mp.full.pupil_mask_file = [file_dir, 'SPM_jg36_79c81_PH40_65deg_26WA90_20LS96_RoC1_LS95deg_BW15Nlam6.fits'];        mp.fracBW = 0.15; mp.Nsbp = 5;%--SPM file name
 % mp.full.pupil_mask_file = [file_dir, 'minpadSPM_jg36_79c81_PH40_65deg_26WA90_20LS96_RoC1_LS95deg_BW15Nlam6.fits'];  mp.fracBW = 0.15; mp.Nsbp = 5;%--SPM file name
@@ -442,7 +443,7 @@ mp.F3.compact.res = 6;    % sampling of FPM for compact model [pixels per lambda
 %% Optical Layout: Full Model 
 
 mp.full.data_dir = '/Users/ajriggs/Repos/proper-models/wfirst_cgi/data_phaseb/'; % mask design data path
-mp.full.cor_type = 'spc_ifs_custom'; %   'hlc', 'spc', or 'none' (none = clear aperture, no coronagraph)
+mp.full.cor_type = 'spc_spec_custom'; %   'hlc', 'spc', or 'none' (none = clear aperture, no coronagraph)
 
 mp.full.flagGenFPM = false;
 mp.full.flagPROPER = true; %--Whether the full model is a PROPER prescription

--- a/wfirst_modeling/EXAMPLE_main_WFIRST_PhaseB_PROPER_SPC_Spec_baseline.m
+++ b/wfirst_modeling/EXAMPLE_main_WFIRST_PhaseB_PROPER_SPC_Spec_baseline.m
@@ -38,7 +38,7 @@ addpath(genpath(mp.path.proper)) %--Add PROPER library to MATLAB path
 
 %% Step 2: Load default model parameters
 
-EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_IFS
+EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_Spec
 
 
 %% Step 3: Overwrite default values as desired
@@ -174,7 +174,7 @@ mp.P1.compact.E = E0;
 mp.path = paths;
 
 %--Re-initialize mp structure
-EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_IFS %--Load default model parameters
+EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_Spec %--Load default model parameters
 
 mp.SeriesNum = sn;
 mp.TrialNum = tn;

--- a/wfirst_modeling/EXAMPLE_main_WFIRST_PhaseB_PROPER_SPC_Spec_custom.m
+++ b/wfirst_modeling/EXAMPLE_main_WFIRST_PhaseB_PROPER_SPC_Spec_custom.m
@@ -38,7 +38,7 @@ addpath(genpath(mp.path.proper)) %--Add PROPER library to MATLAB path
 
 %% Step 2: Load default model parameters
 
-EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_IFS_custom
+EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_Spec_custom
 
 %% Step 3a: Overwrite default values as desired
 
@@ -163,7 +163,7 @@ mp.P1.compact.E = E0;
 mp.path = paths;
 
 %--Re-initialize mp structure
-EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_IFS_custom %--Load default model parameters
+EXAMPLE_defaults_WFIRST_PhaseB_PROPER_SPC_Spec_custom %--Load default model parameters
 
 mp.SeriesNum = sn;
 mp.TrialNum = tn;

--- a/wfirst_modeling/model_compact_wfirst_phaseb.m
+++ b/wfirst_modeling/model_compact_wfirst_phaseb.m
@@ -105,7 +105,7 @@ elseif  strcmp(cor_type,'hlc_erkin')
     n_small = 1024;	% gridsize in non-critical areas
     n_big =2048;    % gridsize to/from FPM
 
-elseif  contains(cor_type, 'spc-ifs' ) %~isempty(strfind(cor_type,  'spc-ifs' ))
+elseif  contains(cor_type, 'spc-spec' )
     file_dir = [data_dir '/spc_20190130/'];        %   must have trailing "/"
     pupil_diam_pix  = 1000.0;
     pupil_file      = [file_dir  'pupil_SPC-20190130_rotated.fits'];
@@ -114,7 +114,7 @@ elseif  contains(cor_type, 'spc-ifs' ) %~isempty(strfind(cor_type,  'spc-ifs' ))
     lyot_stop_file  = [file_dir  'lyotstop_0.5mag.fits'];
     fpm_sampling_lam0 = 0.05;	%   sampling in lambda0/D of FPM mask
     lambda0_m = 0.73e-6;        %   FPM scaled for this central wavelength
-    if ( contains(cor_type,'spc-ifs_short' ));  lambda0_m = 0.66e-6; end 
+    if ( contains(cor_type,'spc-spec_short' ));  lambda0_m = 0.66e-6; end 
     n_small = 2048;             %   gridsize in non-critical areas
     n_big = 1400;               %   gridsize to FPM (propagation to/from FPM handled by MFT)
 elseif  strcmp(cor_type, 'spc-wide' )

--- a/wfirst_modeling/model_full_wfirst_phaseb.m
+++ b/wfirst_modeling/model_full_wfirst_phaseb.m
@@ -50,7 +50,7 @@ function [wavefront,  sampling_m]= model_full_wfirst_phaseb(lambda_m, output_dim
 
 %--mask design data path
 
-data_dir = '/home/krist/afta/phaseb/phaseb_data';  % no trailing '/'
+data_dir = '/home/krist/cgi/phaseb/phaseb_data';  % no trailing '/'
 
 if ( isfield(optval,'data_dir') )
     data_dir = optval.data_dir;
@@ -204,7 +204,7 @@ elseif  strcmp(cor_type,'hlc_custom')
     if  use_fpm;    n_to_fpm = 2048; else; n_to_fpm = 1024; end
     n_from_lyotstop = 1024;
     field_stop_radius_lam0 = 9.0; 
-elseif(strcmpi(cor_type, 'spc_ifs_custom')) 
+elseif(strcmpi(cor_type, 'spc_spec_custom')) 
     pupil_file = optval.pupil_file;
     pupil_diam_pix = optval.pupil_diam_pix; %1000;
     pupil_mask_file = optval.pupil_mask_file;% [file_dir  'SPM_SPC-20190130.fits']; %--SPM file name
@@ -218,7 +218,7 @@ elseif(strcmpi(cor_type, 'spc_ifs_custom'))
     n_mft = 1400;
     n_from_lyotstop = 4096;
     
-elseif  sum(strfind(cor_type, 'spc-ifs' ))
+elseif  sum(strfind(cor_type, 'spc-spec' ))
     file_dir = [data_dir '/spc_20190130/'];       % must have trailing "/"
     pupil_diam_pix = 1000;
     pupil_file = [file_dir  'pupil_SPC-20190130_rotated.fits'];
@@ -227,7 +227,7 @@ elseif  sum(strfind(cor_type, 'spc-ifs' ))
     fpm_sampling_lam0 = 0.05; 	% sampling in lambda0/D of FPM mask
     lyot_stop_file = [file_dir  'LS_SPC-20190130.fits'];
     lambda0_m = 0.73e-6;        % FPM scaled for this central wavelength
-    if strcmp(cor_type, 'spc-ifs_short'); lambda0_m = 0.66e-6;  end      
+    if strcmp(cor_type, 'spc-spec_short'); lambda0_m = 0.66e-6;  end      
     n_default = 2048;           % gridsize in non-critical areas
     n_to_fpm = 2048;            % gridsize to/from FPM
     n_mft = 1400;


### PR DESCRIPTION
- Modified falco_gen_SW_mask to have top be in the up orientation. inputs.clockAngDeg now combines with the orientation instead of overruling it.
- Fixed a bug in the EFC controllers that was not letting the regularization be chosen with a model-based grid search.
- Updated WFIRST CGI functions for the new falco_gen_SW_mask function and to specify "spec" instead of "ifs" because the IFS was replaced by a slit spectrograph.