### PR TITLE
SCDA: Added functions to generate segment-level Zernike aberrations

### DIFF
--- a/lib/masks/demo_gen_pupil_customHex_segmentLevelZernikes.m
+++ b/lib/masks/demo_gen_pupil_customHex_segmentLevelZernikes.m
@@ -1,0 +1,143 @@
+% Copyright 2018, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+clear; 
+
+% %%--Add FALCO and PROPER to the MATLAB Path !!!
+% mp.path.falco = '~/Repos/falco-matlab/';  %--Location of FALCO
+% mp.path.proper = '~/Documents/MATLAB/PROPER/'; %--Location of the MATLAB PROPER library
+% addpath(genpath(mp.path.falco)) %--Add FALCO library to MATLAB path
+% addpath(genpath(mp.path.proper)) %--Add PROPER library to MATLAB path
+
+%% Amplitude only (Keck pupil)
+
+apDia = 1000;
+input.Nbeam = apDia; % number of points across the pupil diameter
+input.wGap = 25.4/10918*apDia/2; % samples
+input.numRings = 3;% Number of rings in hexagonally segmented mirror 
+input.Npad = 2^(nextpow2(apDia));
+input.ID = 2600/10949; % central obscuration radius 
+input.OD = 2; % pupil outer diameter, can be < 1
+input.Nstrut = 6;% Number of struts 
+input.angStrut = [0 60 120 180 240 300];%Angles of the struts (deg)
+input.wStrut = 25.4/10949; % Width of the struts (fraction of pupil diam.)
+
+PUPIL = falco_gen_pupil_customHex( input );
+
+figure(1);
+imagesc((PUPIL));
+axis image;
+set(gca,'ydir','normal');
+
+%% Piston and tip-tilt errors (Keck pupil)
+piston_std = 1/100; %waves
+tilt_std = 1/10; %lambda/D
+
+numSegments = hexSegMirror_numSegments( input.numRings );
+
+input.pistons = piston_std.*randn(1,numSegments);% Vector of pistons per segment (waves)
+input.tiltxs = tilt_std*randn(1,numSegments); % Vector of x-tilts per segment (waves/apDia)
+input.tiltys = tilt_std*randn(1,numSegments);% Vector of y-tilts per segment (waves/apDia)
+
+PUPIL = falco_gen_pupil_customHex( input );
+
+figure(2);
+subplot(1,2,1);
+imagesc(abs(PUPIL));
+axis image;
+set(gca,'ydir','normal');
+subplot(1,2,2);
+imagesc(angle(PUPIL));
+axis image;
+set(gca,'ydir','normal');
+
+%% Add segment level aberrations (Keck pupil)
+
+input.pistons = zeros(1,numSegments);% Vector of pistons per segment (waves)
+input.tiltxs = zeros(1,numSegments); % Vector of x-tilts per segment (waves/apDia)
+input.tiltys = zeros(1,numSegments);% Vector of y-tilts per segment (waves/apDia)
+
+
+coeff = 1/10; % standard deviataion of the randomly-generated
+                  % segment-level Zernike errors in units of waves rms 
+noll_indices = 9; % Noll indicies excluding piston, tip, tilt 
+
+
+% Loop over the segments and fill in the loworder_struct 
+for segment_index = 1:numSegments
+    loworder_struct(segment_index).noll_indices = noll_indices;
+    loworder_struct(segment_index).waves_rms = coeff;
+end
+
+input.loworder_struct = loworder_struct;
+
+PUPIL = falco_gen_pupil_customHex( input );
+
+figure(3);
+subplot(1,2,1);
+imagesc(abs(PUPIL));
+axis image;
+set(gca,'ydir','normal');
+subplot(1,2,2);
+imagesc(angle(PUPIL));
+axis image;
+set(gca,'ydir','normal');
+
+%%
+
+coeff_std = 1/50; % standard deviataion of the randomly-generated
+                  % segment-level Zernike errors in units of waves rms 
+noll_indices = 4:11; % Noll indicies excluding piston, tip, tilt 
+
+
+% Loop over the segments and fill in the loworder_struct 
+for segment_index = 1:numSegments
+    loworder_struct(segment_index).noll_indices = noll_indices;
+    loworder_struct(segment_index).waves_rms = coeff_std*randn(1,numel(noll_indices));
+end
+
+input.loworder_struct = loworder_struct;
+
+PUPIL = falco_gen_pupil_customHex( input );
+
+figure(4);
+subplot(1,2,1);
+imagesc(abs(PUPIL));
+axis image;
+set(gca,'ydir','normal');
+subplot(1,2,2);
+imagesc(angle(PUPIL));
+axis image;
+set(gca,'ydir','normal');
+
+%% LUVOIR A
+clear input;
+input.Nbeam = apDia; % number of points across the pupil diameter
+input.wGap = 25.4/10918*apDia/2; % samples
+input.numRings = 7;% Number of rings in hexagonally segmented mirror 
+input.Npad = 2^(nextpow2(apDia));
+input.ID = 0; % central obscuration radius 
+input.OD = 2; % pupil outer diameter, can be < 1
+input.Nstrut = 0;% Number of struts 
+input.angStrut = [];%Angles of the struts (deg)
+input.wStrut = 0; % Width of the struts (fraction of pupil diam.)
+
+numSegments = hexSegMirror_numSegments( input.numRings );
+
+input.pistons = piston_std.*randn(1,numSegments);% Vector of pistons per segment (waves)
+input.tiltxs = tilt_std*randn(1,numSegments); % Vector of x-tilts per segment (waves/apDia)
+input.tiltys = tilt_std*randn(1,numSegments);% Vector of y-tilts per segment (waves/apDia)
+
+PUPIL = falco_gen_pupil_customHex( input );
+
+figure(5);
+subplot(1,2,1);
+imagesc(abs(PUPIL));
+axis image;
+set(gca,'ydir','normal');
+subplot(1,2,2);
+imagesc(angle(PUPIL));
+axis image;
+set(gca,'ydir','normal');

--- a/lib/masks/falco_gen_pupil_customHex.m
+++ b/lib/masks/falco_gen_pupil_customHex.m
@@ -27,7 +27,8 @@ function PUPIL = falco_gen_pupil_customHex( input )
     [THETA,RHO] = cart2pol(X,Y); 
    
     input.apDia = input.Nbeam;
-    if(isfield(input,'pistons'))
+    if(isfield(input,'pistons') || isfield(input,'tiltxs') || ...
+                isfield(input,'tiltys') || isfield(input,'loworder_struct'))
         PUPIL0 = hexSegMirror_getField( input );
     else
         PUPIL0 = hexSegMirror_getSupport( input );

--- a/lib/masks/falco_gen_pupil_customHex.m
+++ b/lib/masks/falco_gen_pupil_customHex.m
@@ -13,9 +13,6 @@
 % inputs.wStrut - strut width (fraction of Nbeam)
 
 function PUPIL = falco_gen_pupil_customHex( input )
-%gen_pupil_SCDA Generates a simple pupil.
-%   Function may be used to generate circular, annular, and simple on-axis 
-%   telescopes with radial struts. 
 
     hg_expon = 1000; % hyper-gaussian exponent for anti-aliasing 
     hg_expon_spider = 100; % hyper-gaussian exponent for anti-aliasing 

--- a/lib/masks/segMirrorFunctions/hexSegMirror_getField.m
+++ b/lib/masks/segMirrorFunctions/hexSegMirror_getField.m
@@ -15,7 +15,9 @@ function [ OUT ] = hexSegMirror_getField( hexMirror_struct )
 %   pistons - Segment pistons in waves
 %   tiltxs - Tilts on segment in horizontal direction (waves/apDia)
 %   tiltys - Tilts on segment in vertical direction (waves/apDia)
-
+%   loworder_struct - Structure that defines segment-level low order aberrations. 
+%                      loworder_struct(i).noll_indices - list of noll indices for the ith segment. 
+%                      loworder_struct(i).waves_rms - Zernike coefficients for the ith segment in units of waves rms. 
 
 apDia = hexMirror_struct.apDia; % flat to flat aperture diameter (samples)
 wGap = hexMirror_struct.wGap; % samples
@@ -24,6 +26,11 @@ N = hexMirror_struct.Npad;
 pistons = hexMirror_struct.pistons;
 tiltxs = hexMirror_struct.tiltxs; 
 tiltys = hexMirror_struct.tiltys; 
+if(isfield(hexMirror_struct,'loworder_struct'))
+    loworder_struct = hexMirror_struct.loworder_struct;
+else
+    loworder_struct = nan(1,hexSegMirror_numSegments( numRings ));
+end
 
 if(isfield(hexMirror_struct,'missingSegments'))
     missingSegments = hexMirror_struct.missingSegments;
@@ -45,7 +52,7 @@ for ringNum = 0:numRings
     
     if(missingSegments(segNum)==1)
         [ OUT ] = hexSegMirror_addHexSegment( cenrow, cencol, numRings, apDia, ...
-                    wGap, pistons(segNum), tiltxs(segNum), tiltys(segNum), OUT);
+                    wGap, pistons(segNum), tiltxs(segNum), tiltys(segNum), loworder_struct(segNum), OUT);
     end
     segNum = segNum + 1;
     
@@ -65,7 +72,7 @@ for ringNum = 0:numRings
             else
                 if(missingSegments(segNum)==1)
                     [ OUT ] = hexSegMirror_addHexSegment( cenrow, cencol, numRings, apDia, ...
-                                wGap, pistons(segNum), tiltxs(segNum), tiltys(segNum), OUT);
+                                wGap, pistons(segNum), tiltxs(segNum), tiltys(segNum), loworder_struct(segNum), OUT);
                 end
                 segNum = segNum + 1;
             end

--- a/lib/utils/propcustom_gen_zernike.m
+++ b/lib/utils/propcustom_gen_zernike.m
@@ -1,0 +1,15 @@
+function [ Z, n, m ] = propcustom_gen_zernike( noll_index, apRad, RHO, THETA  )
+%propcustom_gen_zernike Generates a Zernike polynomial in 2D array with
+%coordinates defined by RHO, THETA (meshgrid in polar coordinates) and the
+%beam radius, apRad. 
+
+    % Convert from noll index to Zernike indices
+    [ n, m ] = propcustom_zernikes_noll2index( noll_index );
+
+    % Get Zernike polynomial
+    Z = zeros(size(RHO));
+    Z0 = zernfun(n,m,RHO(RHO<=apRad)/apRad,THETA(RHO<=apRad),'norm');
+    Z(RHO<=apRad) = sqrt(pi)*Z0(:,1);
+
+end
+

--- a/lib/utils/propcustom_zernikes_noll2index.m
+++ b/lib/utils/propcustom_zernikes_noll2index.m
@@ -1,0 +1,18 @@
+function [ n, m ] = propcustom_zernikes_noll2index( noll_index )
+%propcustom_zernikes_noll2index Converts the Noll index to Zernike indices.
+% i.e. Z_j -> Z_{n,m}
+% 
+% Helper function for using propcustom_zernikes.m 
+
+    % Convert from noll index to Zernike indices
+    n = 0;
+    j1 = noll_index-1;
+    while(j1 > n)
+        n = n + 1;
+        j1 = j1 - n;
+    end
+
+    m = (-1)^noll_index  * (mod(n,2) + 2 * floor((j1+mod(n+1,2)) / 2.0 ));
+
+end
+

--- a/setup/falco_config_gen_chosen_pupil.m
+++ b/setup/falco_config_gen_chosen_pupil.m
@@ -156,7 +156,12 @@ switch upper(mp.whichPupil)
         end
         if(isfield(mp.P1,'tiltxs'))
             input.tiltxs = mp.P1.tiltxs; % Tilts on segments (waves/apDia)
+        end
+        if(isfield(mp.P1,'tiltys'))
             input.tiltys = mp.P1.tiltys; % Tilts on segments (waves/apDia)
+        end
+        if(isfield(mp.P1,'loworder_struct'))
+            input.loworder_struct = mp.P1.loworder_struct; % Segment-level low order aberration structure
         end
 
         missingSegments = ones(1,hexSegMirror_numSegments(input.numRings));
@@ -172,7 +177,7 @@ switch upper(mp.whichPupil)
         input.Npad = 2^(nextpow2(mp.P1.compact.Nbeam));
         mp.P1.compact.mask = falco_gen_pupil_customHex(input);
         
-        if(isfield(mp.P1,'pistons') || isfield(mp.P1,'tiltxs') || isfield(mp.P1,'tiltys'))
+        if(isfield(mp.P1,'pistons') || isfield(mp.P1,'tiltxs') || isfield(mp.P1,'tiltys') || isfield(mp.P1,'loworder_struct'))
             
             % Compact model has one field per sub-bandpass 
             for sbpIndex = 1:mp.Nsbp


### PR DESCRIPTION
- Added functionality to lib/masks/segMirrorFunctions to introduce segment-level Zernike aberrations. 
- There is a new optional input to falco_gen_pupil_customHex(input) that is input.loworder_struct. input.loworder_struct(i).noll_indices and input.input.loworder_struct(i).waves_rms defines the individual terms to sum up and their magnitude for the ith segment. 
- Piston, tip, and tilt can still be added the old way. Keep in mind that input.pistons, input.tiltxs, and input.tiltys will add on top of the aberrations in loworder_struct. Having both ways may be useful for adding perturbations. 
- I included examples in demo_gen_pupil_customHex_segmentLevelZernikes.m