### PR TITLE
ZWFS: update to reconstructors 

### DIFF
--- a/lib/wfsc/falco_zwfs_diff_reconstructor.m
+++ b/lib/wfsc/falco_zwfs_diff_reconstructor.m
@@ -1,6 +1,9 @@
-function phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, type)
+function phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, type, varargin)
 % phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, type)
 %   Function to estimate the phase difference from Zernike WFS measurements
+%   Assumes that the difference in phase between I0 and Iref is small. 
+%   Allows for a correction based on an estimate of the phase corresponding
+%   to Iref. 
 %   
 %   Inputs:
 %       I0 - image with Zernike mask misaligned 
@@ -9,22 +12,53 @@ function phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, type)
 %       mask - pupil support mask 
 %       b - Reference wave
 %       theta - mask phase shift, typically 2*pi*mp.F3.t*(mp.F3.n(mp.lambda0)-1)/mp.lambda0;
-%       type - string - 'linear' reconstructor 
+%       type - string - 'linear' for linear reconstructor, 'first' for first order correction 
+%                       anything beyond linear requires the reference phase estimate 
+%                       phz_ref to be passed as first varargin. 
+%
+%       Use 'linear' when you have no clue what the phase is for the
+%       reference image, but you know it is small (<< 1 radian). 
+%       Introducing an estimate of phz_ref can reduce this error.
+%
+%       If either the reference phase or phase difference are substantial,
+%       use the full reconstructor in falco_zwfs_reconstructor
 %
 %   Output:
 %       phz - A 2D array with the estimated phase 
 
     P = sqrt(I0);
     b = mean(P(mask))*b; % Scale reference wave to match incident energy
+    
+    denom = 2*b.*P.*sin(theta);
+    phz = (IZ - Iref)./denom;% first order phase difference approximation 
 
 	if( strcmpi(type,'linear') || strcmpi(type,'l') )
         
-        denom = 2*b.*P.*sin(theta);
-        phz = (IZ - Iref)./denom;
+        % we're done here
+        correction = 1; 
         
-    else
+	elseif( strcmpi(type,'first') || strcmpi(type,'firstorder') )
+        
+        phz_ref = varargin{1}; 
+        
+        a1 = (1-cos(theta))/sin(theta);
+        
+        correction = 1 - a1*phz_ref; 
+        
+	elseif( strcmpi(type,'second') || strcmpi(type,'secondorder') )
+        
+        phz_ref = varargin{1}; 
+        
+        a1 = (1-cos(theta))/sin(theta);
+        a2 = (1/cos(theta/2)^2 - 1/2);
+        
+        correction = 1 - a1*phz_ref + a2*phz_ref.^2; 
+        
+	else
         error('Reconstructor undefined');
     end
+    
+    phz = phz.*correction; 
 
 	phz = phz - mean(phz(mask));
 

--- a/lib/wfsc/falco_zwfs_diff_reconstructor.m
+++ b/lib/wfsc/falco_zwfs_diff_reconstructor.m
@@ -1,9 +1,9 @@
-function phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, type, varargin)
-% phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, type)
+function phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, varargin)
+% phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, <phz_ref>)
 %   Function to estimate the phase difference from Zernike WFS measurements
-%   Assumes that the difference in phase between I0 and Iref is small. 
-%   Allows for a correction based on an estimate of the phase corresponding
-%   to Iref. 
+%   Assumes that the difference in phase between IZ and Iref is small. 
+%   Also allows for a correction based on an estimate of the phase 
+%   corresponding to Iref. 
 %   
 %   Inputs:
 %       I0 - image with Zernike mask misaligned 
@@ -12,54 +12,27 @@ function phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, type,
 %       mask - pupil support mask 
 %       b - Reference wave
 %       theta - mask phase shift, typically 2*pi*mp.F3.t*(mp.F3.n(mp.lambda0)-1)/mp.lambda0;
-%       type - string - 'linear' for linear reconstructor, 'first' for first order correction 
-%                       anything beyond linear requires the reference phase estimate 
-%                       phz_ref to be passed as first varargin. 
+%       varargin{1} - phz_ref - The reference absolute phase estimate 
 %
-%       Use 'linear' when you have no clue what the phase is for the
-%       reference image, but you know it is small (<< 1 radian). 
-%       Introducing an estimate of phz_ref can reduce this error.
-%
-%       If either the reference phase or phase difference are substantial,
+%       If either the phase difference is substantial,
 %       use the full reconstructor in falco_zwfs_reconstructor
 %
 %   Output:
 %       phz - A 2D array with the estimated phase 
 
-    P = sqrt(I0);
-    b = mean(P(mask))*b; % Scale reference wave to match incident energy
+    A = sqrt(I0);
+    b = mean(A(mask))*b; % Scale reference wave to match incident energy
     
-    denom = 2*b.*P.*sin(theta);
-    phz = (IZ - Iref)./denom;% first order phase difference approximation 
-
-	if( strcmpi(type,'linear') || strcmpi(type,'l') )
-        
-        % we're done here
-        correction = 1; 
-        
-	elseif( strcmpi(type,'first') || strcmpi(type,'firstorder') )
-        
-        phz_ref = varargin{1}; 
-        
-        a1 = (1-cos(theta))/sin(theta);
-        
-        correction = 1 - a1*phz_ref; 
-        
-	elseif( strcmpi(type,'second') || strcmpi(type,'secondorder') )
-        
-        phz_ref = varargin{1}; 
-        
-        a1 = (1-cos(theta))/sin(theta);
-        a2 = (1/cos(theta/2)^2 - 1/2);
-        
-        correction = 1 - a1*phz_ref + a2*phz_ref.^2; 
-        
-	else
-        error('Reconstructor undefined');
+    if(nargin==1)
+        phz_ref = varargin{1};
+        beta = sin(theta)*cos(phz_ref) + (1-cos(theta))*sin(phz_ref);
+    else
+        beta = sin(theta);
     end
     
-    phz = phz.*correction; 
+    denom = 2*b.*A.*beta;
+    phz = (IZ - Iref)./denom;% first order phase difference approximation 
 
-	phz = phz - mean(phz(mask));
+	phz = phz - mean(phz(mask));% subtract of constant offset 
 
 end

--- a/lib/wfsc/falco_zwfs_diff_reconstructor.m
+++ b/lib/wfsc/falco_zwfs_diff_reconstructor.m
@@ -1,0 +1,31 @@
+function phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, type)
+% phz = falco_zwfs_diff_reconstructor(I0, IZ, Iref, mask, b, theta, type)
+%   Function to estimate the phase difference from Zernike WFS measurements
+%   
+%   Inputs:
+%       I0 - image with Zernike mask misaligned 
+%       IZ - image with Zernike mask aligned 
+%       Iref - Reference image (also with Zernike mask aligned)
+%       mask - pupil support mask 
+%       b - Reference wave
+%       theta - mask phase shift, typically 2*pi*mp.F3.t*(mp.F3.n(mp.lambda0)-1)/mp.lambda0;
+%       type - string - 'linear' reconstructor 
+%
+%   Output:
+%       phz - A 2D array with the estimated phase 
+
+    P = sqrt(I0);
+    b = mean(P(mask))*b; % Scale reference wave to match incident energy
+
+	if( strcmpi(type,'linear') || strcmpi(type,'l') )
+        
+        denom = 2*b.*P.*sin(theta);
+        phz = (IZ - Iref)./denom;
+        
+    else
+        error('Reconstructor undefined');
+    end
+
+	phz = phz - mean(phz(mask));
+
+end

--- a/lib/wfsc/falco_zwfs_reconstructor.m
+++ b/lib/wfsc/falco_zwfs_reconstructor.m
@@ -13,30 +13,30 @@ function phz = falco_zwfs_reconstructor(I0,IZ, mask, b, theta, type)
 %   Output:
 %       phz - A 2D array with the estimated phase 
 
-    P = sqrt(I0);
-    b = mean(P(mask))*b; % Scale reference wave to match incident energy
+    A = sqrt(I0);
+    b = mean(A(mask))*b; % Scale reference wave to match incident energy
     
 	if( strcmpi(type,'linear') || strcmpi(type,'l') ) % Linear approximation 
         
-        denom = 2*b.*P.*sin(theta);
-        term2 = P.^2 + (2*b.^2 - 2*b.*P)*(1-cos(theta));
+        denom = 2*b.*A.*sin(theta);
+        term2 = A.^2 + (2*b.^2 - 2*b.*A)*(1-cos(theta));
         phz = (IZ - term2)./denom;
         
     elseif( strcmpi(type,'ndiaye') || strcmpi(type,'n') ) % Second order approximation
 
-        a1 = 2*b.*P.*(-2*b.^2+IZ+3*b.*P-P.^2+b.*(2*b-P)*cos(theta))*sin(theta/2)^2;
-        a2 = b.*P.*sin(theta);
+        a1 = 2*b.*A.*(-2*b.^2+IZ+3*b.*A-A.^2+b.*(2*b-A)*cos(theta))*sin(theta/2)^2;
+        a2 = b.*A.*sin(theta);
         numer = sqrt(a1) + a2;
-        denom = b.*P*(cos(theta)-1);
+        denom = b.*A*(cos(theta)-1);
         phz = -1*real(numer./(denom+1e-30)); 
         
     elseif( strcmpi(type,'full') || strcmpi(type,'f') ) % Full analytical solution 
         
-        a0 = 4*b.^2.*(IZ+P.^2)-6*b.^4-(IZ-P.^2).^2-4*b.^2.*(IZ+P.^2-2*b.^2)*cos(theta)-2*b.^4*cos(2*theta);
-        a1 = b.^2.*P.^2.*sin(theta)^2.*a0;
-        a2 = b.*P.*(P.^2-IZ).*(cos(theta)-1)-2*b.^3.*P.*(cos(theta)-1)^2;
+        a0 = 4*b.^2.*(IZ+A.^2)-6*b.^4-(IZ-A.^2).^2-4*b.^2.*(IZ+A.^2-2*b.^2)*cos(theta)-2*b.^4*cos(2*theta);
+        a1 = b.^2.*A.^2.*sin(theta)^2.*a0;
+        a2 = b.*A.*(A.^2-IZ).*(cos(theta)-1)-2*b.^3.*A.*(cos(theta)-1)^2;
         numer = a2 + sqrt(a1); % plus or minus are valid solutions 
-        denom = 4.*b.^2.*P.^2.*(cos(theta)-1);
+        denom = 4.*b.^2.*A.^2.*(cos(theta)-1);
         phz = real(acos(numer./(denom+1e-30))); % plus or minus are valid solutions 
         
     else

--- a/lib/wfsc/falco_zwfs_reconstructor.m
+++ b/lib/wfsc/falco_zwfs_reconstructor.m
@@ -1,28 +1,46 @@
-function phz = falco_zwfs_reconstructor(IC0,IC, mask, b, type,varargin)
-% IC0 - image without Zernike mask
-% IC - image with Zernike mask aligned 
-% mask - pupil support mask 
-% b - Reference wave
-% type - string - 'wallace' or 'ndiaye' reconstructors 
-% Need to pass mp when using ndiaye
+function phz = falco_zwfs_reconstructor(I0,IZ, mask, b, theta, type)
+% phz = falco_zwfs_reconstructor(I0,IZ, mask, b, theta, type)
+%   Function to estimate the phase from Zernike WFS data
+%   
+%   Inputs:
+%       I0 - image without Zernike mask
+%       IZ - image with Zernike mask aligned 
+%       mask - pupil support mask 
+%       b - Reference wave
+%       theta - mask phase shift, typically 2*pi*mp.F3.t*(mp.F3.n(mp.lambda0)-1)/mp.lambda0;
+%       type - string - 'linear', 'ndiaye', or 'full' reconstructors 
+%
+%   Output:
+%       phz - A 2D array with the estimated phase 
 
-    A02 = mean(IC0(mask));
-    P = sqrt(IC0/A02);
+    P = sqrt(I0);
+    b = mean(P(mask))*b; % Scale reference wave to match incident energy
+    
+	if( strcmpi(type,'linear') || strcmpi(type,'l') ) % Linear approximation 
+        
+        denom = 2*b.*P.*sin(theta);
+        term2 = P.^2 + (2*b.^2 - 2*b.*P)*(1-cos(theta));
+        phz = (IZ - term2)./denom;
+        
+    elseif( strcmpi(type,'ndiaye') || strcmpi(type,'n') ) % Second order approximation
 
-    if(strcmp(type,'wallace')||strcmp(type,'Wallace')||strcmp(type,'w')||strcmp(type,'W'))
-        numer = IC - A02*(P.^2 + 2*b.^2);
-        denom = 2*sqrt(2)*A02*P.*b;
-        phz = real(pi/4 + asin(numer./denom));
-    elseif(strcmp(type,'NDiaye')||strcmp(type,'Ndiaye')||strcmp(type,'ndiaye')||strcmp(type,'n')||strcmp(type,'N'))
-        mp = varargin{1};
-        theta = 2*pi*mp.F3.t*(mp.F3.n(mp.lambda0)-1)/mp.lambda0;
-        a1 = 2*b.*P.*(-2*b.^2+IC+3*b.*P-P.^2+b.*(2*b-P)*cos(theta))*sin(theta/2)^2;
+        a1 = 2*b.*P.*(-2*b.^2+IZ+3*b.*P-P.^2+b.*(2*b-P)*cos(theta))*sin(theta/2)^2;
         a2 = b.*P.*sin(theta);
         numer = sqrt(a1) + a2;
-        denom = b.*P.*(cos(theta)-1);
-        phz = real(numer./(denom+1e-30)); 
+        denom = b.*P*(cos(theta)-1);
+        phz = -1*real(numer./(denom+1e-30)); 
+        
+    elseif( strcmpi(type,'full') || strcmpi(type,'f') ) % Full analytical solution 
+        
+        a0 = 4*b.^2.*(IZ+P.^2)-6*b.^4-(IZ-P.^2).^2-4*b.^2.*(IZ+P.^2-2*b.^2)*cos(theta)-2*b.^4*cos(2*theta);
+        a1 = b.^2.*P.^2.*sin(theta)^2.*a0;
+        a2 = b.*P.*(P.^2-IZ).*(cos(theta)-1)-2*b.^3.*P.*(cos(theta)-1)^2;
+        numer = a2 + sqrt(a1); % plus or minus are valid solutions 
+        denom = 4.*b.^2.*P.^2.*(cos(theta)-1);
+        phz = real(acos(numer./(denom+1e-30))); % plus or minus are valid solutions 
+        
     else
-        disp('Reconstructor undefined');
+        error('Reconstructor undefined');
     end
 
 	phz = phz - mean(phz(mask));


### PR DESCRIPTION
- Updated reconstructors to agree on sign convention and allow for arbitrary FPM phase shift. 
- Added a separate, simpler function meant only for differential measurements. 
- Updated the Example file