### PR TITLE
ZWFS: major update 

### DIFF
--- a/lib/wfsc/falco_zwfs_getCalibrationImage.m
+++ b/lib/wfsc/falco_zwfs_getCalibrationImage.m
@@ -1,0 +1,9 @@
+function Ical = falco_zwfs_getCalibrationImage(mp)
+% Simluates the calibration image for the Zernike wavefront sensor using
+% FALCO model
+
+    mp.wfs.mask.FPMampFac = 1.0;
+    mp.wfs.mask.depth = 0;% Locally modifying the mask depth to zero  
+    Ical = falco_zwfs_sim_image(mp);
+
+end

--- a/lib/wfsc/falco_zwfs_getReferenceWave.m
+++ b/lib/wfsc/falco_zwfs_getReferenceWave.m
@@ -6,10 +6,13 @@ function rw = falco_zwfs_getReferenceWave(mp)
     modvar.sbpIndex = 1;
     
     modvar.whichSource = 'star';
-    modvar.lambda = mp.lambda0;
+    modvar.lambda = mp.wfs.lambda0;
    
+    % assuming the the DMs and nominal phase are flat
     mp.dm1.V = zeros(mp.dm1.Nact);
+    mp.dm2.V = zeros(mp.dm2.Nact);
     mp.P1.full.E = ones(size(mp.P1.full.E));
     rw = model_ZWFS(mp, modvar, 'refwave');
+    rw = abs(rw); 
 
 end

--- a/lib/wfsc/falco_zwfs_reconstructor.m
+++ b/lib/wfsc/falco_zwfs_reconstructor.m
@@ -7,20 +7,20 @@ function phz = falco_zwfs_reconstructor(I0,IZ, mask, b, theta, type)
 %       IZ - image with Zernike mask aligned 
 %       mask - pupil support mask 
 %       b - Reference wave
-%       theta - mask phase shift, typically 2*pi*mp.F3.t*(mp.F3.n(mp.lambda0)-1)/mp.lambda0;
+%       theta - mask phase shift, typically 2*pi*depth*(n-1)/lambda;
 %       type - string - 'linear', 'ndiaye', or 'full' reconstructors 
 %
 %   Output:
 %       phz - A 2D array with the estimated phase 
 
     A = sqrt(I0);
-    b = mean(A(mask))*b; % Scale reference wave to match incident energy
+	b = mean(A(mask))*b; % Scale reference wave to match incident energy
     
 	if( strcmpi(type,'linear') || strcmpi(type,'l') ) % Linear approximation 
         
-        denom = 2*b.*A.*sin(theta);
-        term2 = A.^2 + (2*b.^2 - 2*b.*A)*(1-cos(theta));
-        phz = (IZ - term2)./denom;
+        denom = 2.*b.*A.*sin(theta);
+        term2 = A.^2 + 2*b.^2 - 2*b.*A + 2*b.*(A-b).*cos(theta);
+        phz = (IZ - term2)./(denom+1e-30);
         
     elseif( strcmpi(type,'ndiaye') || strcmpi(type,'n') ) % Second order approximation
 

--- a/lib/wfsc/falco_zwfs_sim_image.m
+++ b/lib/wfsc/falco_zwfs_sim_image.m
@@ -6,23 +6,23 @@ function Isum = falco_zwfs_sim_image(mp)
 
     Isum = 0; % Initialize image
 
-    for si=1:mp.Nsbp
+    for si=1:mp.wfs.Nsbp
         modvar.sbpIndex = si;
 
-        for wi=1:mp.Nwpsbp
+        for wi=1:mp.wfs.Nwpsbp
             modvar.whichSource = 'star';
             modvar.wpsbpIndex = wi;
             Etemp = model_ZWFS(mp, modvar);
 
-            Isum = Isum + (abs(Etemp).^2)*mp.sbp_weights(si)*mp.full.lambda_weights(wi);
+            Isum = Isum + (abs(Etemp).^2)*mp.wfs.sbp_weights(si)*mp.wfs.lambda_weights(wi);
         end 
 
-        if(mp.planetFlag)
-            modvar.whichSource = 'exoplanet';
-            Eout = model_ZWFS(mp,modvar);
-            ImPlanetC = abs(Eout).^2; % In contrast
-            Isum = Isum + ImPlanetC*mp.sbp_weights(si);
-        end
+%         if(mp.planetFlag)
+%             modvar.whichSource = 'exoplanet';
+%             Eout = model_ZWFS(mp,modvar);
+%             ImPlanetC = abs(Eout).^2; % In contrast
+%             Isum = Isum + ImPlanetC*mp.sbp_weights(si);
+%         end
 
     end
 

--- a/setup/falco_configure_WFS.m
+++ b/setup/falco_configure_WFS.m
@@ -1,0 +1,27 @@
+% Copyright 2018, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+%
+% REVISION HISTORY:
+% --------------
+% Created by G. Ruane on 2020-04-21
+% ---------------
+
+function mp = falco_configure_WFS(mp)
+
+    if(mp.flagWFS)
+        
+        mp = falco_gen_FPM_ZWFS(mp);
+        mp = falco_get_FPM_ZWFS_coordinates(mp);
+        mp = falco_set_WFS_spectral_properties(mp);
+        
+        
+        % Intialize E-field seen by WFS (will be different to coronagraph 
+        % if using WFS out of band). This is updated in model_ZWFS.
+        mp.wfs.E = ones(mp.P1.full.Narr,mp.P1.full.Narr,mp.wfs.Nwpsbp,mp.wfs.Nsbp);
+        
+    end
+        
+end %--END OF FUNCTION

--- a/setup/falco_flesh_out_workspace.m
+++ b/setup/falco_flesh_out_workspace.m
@@ -27,6 +27,9 @@ mp = falco_configure_dark_hole_region(mp); %% Software Mask for Correction (corr
 mp = falco_set_spatial_weights(mp); %--Spatial weighting for control Jacobian. 
 % mp.Fend.mask = ones(mp.Fend.Neta,mp.Fend.Nxi); %% Field Stop at Fend (as a software mask) (NOT INCLUDED YET)
 
+%%--Wavefront sensor
+mp = falco_configure_WFS(mp);
+
 %--DM1 and DM2
 mp = falco_configure_dm1_and_dm2(mp); %% Flesh out the dm1 and dm2 structures
 mp = falco_gen_DM_stops(mp);

--- a/setup/falco_gen_FPM_ZWFS.m
+++ b/setup/falco_gen_FPM_ZWFS.m
@@ -1,0 +1,62 @@
+% Copyright 2018, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+%
+% REVISION HISTORY:
+% --------------
+% Created by A.J. Riggs on 2018-10-01 by extracting material from
+% falco_init_ws.m.
+% Modifed from falco_config_gen_FPM_LC by G. Ruane on 2018-11-20.
+% Modifed from falco_gen_FPM_Roddier by G. Ruane on 2020-04-21.
+% ---------------
+
+function mp = falco_gen_FPM_ZWFS(mp)
+
+        %--Make focal plane mask (FPM) amplitude
+        FPMgenInputs.pixresFPM = mp.wfs.mask.res; %--pixels per lambda_c/D
+        FPMgenInputs.rhoInner = mp.wfs.mask.Rin; % radius of inner FPM amplitude spot (in lambda_c/D)
+        FPMgenInputs.rhoOuter = mp.wfs.mask.Rout; % radius of outer opaque FPM ring (in lambda_c/D)
+        FPMgenInputs.FPMampFac = mp.wfs.mask.FPMampFac; % amplitude transmission of inner FPM spot
+        FPMgenInputs.centering = mp.centering;
+        mp.wfs.mask.amp = falco_gen_annular_FPM(FPMgenInputs);
+        
+        %--Number of points across the FPM
+        if(isinf(mp.wfs.mask.Rout))
+            switch mp.centering
+            case 'pixel'
+                mp.wfs.mask.Nxi = ceil_even((2*(mp.wfs.mask.Rin*mp.wfs.mask.res + 1/2)));
+            case 'interpixel'
+                mp.wfs.mask.Nxi = ceil_even((2*mp.wfs.mask.Rin*mp.wfs.mask.res));
+            end
+        else
+            switch mp.centering
+                case 'pixel'
+                    mp.wfs.mask.Nxi = ceil_even((2*(mp.wfs.mask.Rout*mp.wfs.mask.res + 1/2)));
+                case 'interpixel'
+                    mp.wfs.mask.Nxi = ceil_even((2*mp.wfs.mask.Rout*mp.wfs.mask.res));
+            end
+        end
+        mp.wfs.mask.Neta = mp.wfs.mask.Nxi;
+        
+        %-- Make a mask for the phase pattern support
+        FPMgenInputsPhz = FPMgenInputs;
+        FPMgenInputsPhz.FPMampFac = 0;
+        mp.wfs.mask.phzSupport = 1-falco_gen_annular_FPM(FPMgenInputsPhz);
+        
+        % need to define the index of refraction in the case of a
+        % transmissive mask 
+        if(strcmpi(mp.wfs.mask.type,'transmissive'))
+            if(strcmp(mp.wfs.mask.material,'FS'))% Fused silica 
+                nsquared = @(lam_um) 1 + (0.6961663*lam_um^2)/(lam_um^2-0.0684043^2)+ ...
+                                      (0.4079426*lam_um^2)/(lam_um^2-0.1162414^2)+ ...
+                                      (0.8974794*lam_um^2)/(lam_um^2-9.896161^2);          
+                n = @(lam) real(sqrt(nsquared(lam*1e6)));
+                mp.wfs.mask.n = n;
+            else
+                error('Material not defined for Zernike WFS mask.');
+            end
+        end
+
+end %--END OF FUNCTION

--- a/setup/falco_get_FPM_ZWFS_coordinates.m
+++ b/setup/falco_get_FPM_ZWFS_coordinates.m
@@ -1,0 +1,35 @@
+% Copyright 2019, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+%
+% FPM coordinates, [meters] and [dimensionless]
+
+function mp = falco_get_FPM_ZWFS_coordinates(mp)
+
+    lam0 = mp.wfs.lambda0;
+
+    mp.wfs.mask.dxi = (mp.fl*lam0/mp.P2.D)/mp.wfs.mask.res;
+    mp.wfs.mask.deta = mp.wfs.mask.dxi;
+
+    %--Coordinates in FPM plane in the compact model [meters]
+    if(strcmpi(mp.centering,'interpixel') || mod(mp.wfs.mask.Nxi,2)==1)
+        mp.wfs.mask.xis  = (-(mp.wfs.mask.Nxi-1)/2:(mp.wfs.mask.Nxi-1)/2)*mp.wfs.mask.dxi;
+        mp.wfs.mask.etas = (-(mp.wfs.mask.Neta-1)/2:(mp.wfs.mask.Neta-1)/2).'*mp.wfs.mask.deta;
+    else
+        mp.wfs.mask.xis  = (-mp.wfs.mask.Nxi/2: (mp.wfs.mask.Nxi/2-1))*mp.wfs.mask.dxi;
+        mp.wfs.mask.etas = (-mp.wfs.mask.Neta/2:(mp.wfs.mask.Neta/2-1)).'*mp.wfs.mask.deta;
+    end
+
+    %--Coordinates (dimensionless [DL]) for the FPMs in the compact model
+    if(strcmpi(mp.centering,'interpixel') || mod(mp.wfs.mask.Nxi,2)==1)
+        mp.wfs.mask.xisDL  = (-(mp.wfs.mask.Nxi-1)/2:(mp.wfs.mask.Nxi-1)/2)/mp.wfs.mask.res;
+        mp.wfs.mask.etasDL = (-(mp.wfs.mask.Neta-1)/2:(mp.wfs.mask.Neta-1)/2)/mp.wfs.mask.res;
+    else
+        mp.wfs.mask.xisDL  = (-mp.wfs.mask.Nxi/2:(mp.wfs.mask.Nxi/2-1))/mp.wfs.mask.res;
+        mp.wfs.mask.etasDL = (-mp.wfs.mask.Neta/2:(mp.wfs.mask.Neta/2-1))/mp.wfs.mask.res;
+    end
+
+
+end %--END OF FUNCTION

--- a/setup/falco_set_WFS_spectral_properties.m
+++ b/setup/falco_set_WFS_spectral_properties.m
@@ -1,0 +1,108 @@
+% Copyright 2019, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+%
+% Spectral weighting of images. 
+%
+%
+% REVISION HISTORY:
+% --------------
+% Created by G. Ruane on 2020-04-21 based on falco_set_spectral_properties
+% ---------------
+
+function mp = falco_set_WFS_spectral_properties(mp)
+
+if(~isfield(mp.wfs,'lambda0')); mp.wfs.lambda0 = mp.lambda0; end
+if(~isfield(mp.wfs,'Nsbp')); mp.wfs.Nsbp = 1; end
+if(~isfield(mp.wfs,'Nwpsbp')); mp.wfs.Nwpsbp = 1; end
+if(~isfield(mp.wfs,'fracBW')); mp.wfs.fracBW = 0.01; end
+
+lambda0 = mp.wfs.lambda0;
+Nsbp = mp.wfs.Nsbp;
+Nwpsbp = mp.wfs.Nwpsbp;
+fracBW = mp.wfs.fracBW;
+
+%% Compact Model
+
+%--Center(-ish) wavelength indices (ref = reference). (Only the center if
+%  an odd number of wavelengths is used.)
+mp.wfs.si_ref = ceil(Nsbp/2);
+
+%--Wavelengths used for Compact Model (and Jacobian Model)
+mp.wfs.sbp_weights = ones(Nsbp,1);
+if(mp.wfs.flagSim) %--Set ctrl wavelengths evenly between endpoints (inclusive) of the total bandpass.
+    if(Nsbp==1)
+        mp.wfs.sbp_centers = lambda0;
+    else
+        mp.wfs.sbp_centers = lambda0*linspace(1-fracBW/2,1+fracBW/2,Nsbp);
+        mp.wfs.sbp_weights(1) = 1/2; %--Give end sub-bands half weighting
+        mp.wfs.sbp_weights(end) = 1/2; %--Give end sub-bands half weighting
+    end
+else %--For cases with multiple sub-bands: Choose wavelengths to be at subbandpass centers since the wavelength samples will span to the full extent of the sub-bands.
+    mp.wfs.fracBWcent2cent = fracBW*(1-1/Nsbp); %--Bandwidth between centers of endpoint subbandpasses.
+    mp.wfs.sbp_centers = lambda0*linspace(1-mp.wfs.fracBWcent2cent/2,1+mp.wfs.fracBWcent2cent/2,Nsbp); %--Space evenly at the centers of the subbandpasses.
+end
+mp.wfs.sbp_weights = mp.wfs.sbp_weights/sum(mp.wfs.sbp_weights); %--Normalize the sum of the weights
+
+fprintf(' WFS using %d discrete wavelength(s) in each of %d sub-bandpasses over a %.1f%% total bandpass \n', Nwpsbp, Nsbp, 100*fracBW);
+fprintf('WFS sub-bandpasses are centered at wavelengths [nm]:\t '); fprintf('%.2f  ',1e9*mp.wfs.sbp_centers); fprintf('\n\n');
+
+%% Bandwidth and Wavelength Specs: Full Model
+
+%--Center(-ish) wavelength indices (ref = reference). (Only the center if an odd number of wavelengths is used.)
+mp.wfs.wi_ref = ceil(Nwpsbp/2);
+
+%--Wavelength factors/weights within each sub-bandpass. For full model only
+mp.wfs.lambda_weights = ones(Nwpsbp,1); %--Initialize as all ones. Weights within a single sub-bandpass
+if(Nwpsbp==1) %--Give equal weighting to all wavelengths
+    mp.wfs.dlam = 0; %--Delta lambda between every wavelength in the sub-band in the full model
+else %--Give half weighting to the end wavelengths
+    %--Spectral weighting in image
+    mp.wfs.lambda_weights(1) = 1/2; %--Give end wavelengths half weighting
+    mp.wfs.lambda_weights(end) = 1/2; %--Give end wavelengths half weighting
+    mp.wfs.fracBWsbp = fracBW/Nsbp; %--Bandwidth per sub-bandpass
+    %--Indexing of wavelengths in each sub-bandpass
+    sbp_facs = linspace(1-mp.wfs.fracBWsbp/2,1+mp.wfs.fracBWsbp/2, Nwpsbp); %--Factor applied to lambda0 only
+    mp.wfs.dlam = (sbp_facs(2) - sbp_facs(1))*lambda0; %--Delta lambda between every wavelength in the full model 
+end
+mp.wfs.lambda_weights = mp.wfs.lambda_weights/sum(mp.wfs.lambda_weights); %--Normalize sum of the weights (within the sub-bandpass)
+
+%--Make vector of all wavelengths and weights used in the full model
+lambdas = zeros(Nsbp*Nwpsbp,1);
+lambda_weights_all = zeros(Nsbp*Nwpsbp,1);
+mp.wfs.lambdasMat = zeros(Nsbp,Nwpsbp);
+mp.wfs.indsLambdaMat = zeros(Nsbp*Nwpsbp,2);
+counter = 0;
+for si=1:Nsbp
+    mp.wfs.lambdasMat(si,:) = (-(Nwpsbp-1)/2:(Nwpsbp-1)/2)*mp.wfs.dlam + mp.wfs.sbp_centers(si); 
+    for wi=1:Nwpsbp
+        counter = counter+1;
+        lambdas(counter) = mp.wfs.lambdasMat(si,wi);
+        lambda_weights_all(counter) = mp.wfs.sbp_weights(si)*mp.wfs.lambda_weights(wi);
+        mp.wfs.indsLambdaMat(counter,:) = [si,wi];
+    end
+end
+
+%--Get rid of redundant wavelengths in the complete list, and sum weights for repeated wavelengths
+% indices of unique wavelengths
+[~, inds_unique] = unique(round(1e12*lambdas)); %--Check equality at the picometer level for wavelength
+mp.wfs.indsLambdaUnique = inds_unique;
+% indices of duplicate wavelengths
+duplicate_inds = setdiff( 1:length(lambdas) , inds_unique);
+% duplicate weight values
+duplicate_values = lambda_weights_all(duplicate_inds);
+
+%--Shorten the vectors to contain only unique values. Combine weights for repeated wavelengths.
+mp.wfs.lambdas = lambdas(inds_unique);
+mp.wfs.lambda_weights_all = lambda_weights_all(inds_unique);
+for idup=1:length(duplicate_inds)
+    lambda = lambdas(duplicate_inds(idup));
+    weight = lambda_weights_all(duplicate_inds(idup));
+    ind = find(abs(mp.full.lambdas-lambda)<=1e-11);
+    mp.wfs.lambda_weights_all(ind) = mp.wfs.lambda_weights_all(ind) + weight;
+end
+mp.wfs.NlamUnique = length(inds_unique);
+
+end

--- a/setup/falco_set_optional_variables.m
+++ b/setup/falco_set_optional_variables.m
@@ -50,6 +50,7 @@ if(isfield(mp.ctrl,'flagUseModel')==false);  mp.ctrl.flagUseModel = false;  end 
 if(isfield(mp,'flagFiber')==false);  mp.flagFiber = false;  end  %--Whether to couple the final image through lenslets and a single mode fiber.
 if(isfield(mp,'flagLenslet')==false); mp.flagLenslet = false; end %--Flag to propagate through a lenslet array placed in Fend before coupling light into fibers
 if(isfield(mp,'flagDMwfe')==false);  mp.flagDMwfe = false;  end  %--Temporary for BMC quilting study. Adds print-through to the DM surface.
+if(isfield(mp,'flagWFS')==false);  mp.flagWFS = false;  end  %--Whether to activate the WFS mode 
 
 %--Whether to generate or load various masks: compact model
 if(isfield(mp.compact,'flagGenPupil')==false);  mp.compact.flagGenPupil = true;  end

--- a/setup/falco_set_spectral_properties.m
+++ b/setup/falco_set_spectral_properties.m
@@ -12,7 +12,7 @@
 % Created by A.J. Riggs on 2019-12-10 by extracting material from falco_init_ws.m.
 % ---------------
 
-function mp = falco_set_spectral_weights(mp)
+function mp = falco_set_spectral_properties(mp)
 
 %% Compact Model
 


### PR DESCRIPTION
Major change: To simplify the ZWFS mode, it no longer uses the Roddier coronagraph. Instead, it uses a separate struct called mp.wfs and the ZWFS model is  totally independent from the coronagraph models. However, its follows the same basic structure and naming conventions.
 
New flag: mp.flagWFS – When true, FALCO initializes the mp.wfs sub-struct when falco_flesh_out_workspace is called. The WFS configuration is handled by falco_configure_WFS and the functions called by it. For example, falco_gen_FPM_ZWFS is similar to falco_gen_FPM and falco_set_WFS_spectral_properties is similar to falco_set_spectral_properties.
 
WFSing wavelengths: The WFS can now have totally different wavelengths, using the same naming convention as a “full” coronagraph model. For example,
mp.wfs.lambda0 - Central wavelength of the whole spectral bandpass [meters]
mp.wfs.fracBW - fractional bandwidth of the whole bandpass (Delta lambda / lambda0)
mp.wfs.Nsbp - Number of sub-bandpasses to divide the whole bandpass into
If these are not defined, they will be forced to match the full coronagraph model.
 
ZWFS mask parameters
mp.wfs.mask.type - 'reflective' or ‘transmissive’
mp.wfs.mask.material – Material of FPM. For example, 'FS' is Fused Silica. Required for the transmissive mask and current not used for reflective mask.
mp.wfs.mask.Rin  - Dimple radius in units of lambda/D where
mp.wfs.mask.Rout - Outer radius of WFS FPM in units of lambda/D
mp.wfs.mask.depth - Depth of the Zernike dimple (meters)
mp.wfs.mask.FPMampFac - Zernike dimple amplitude factor for transmission or reflection
mp.wfs.mask.res – Resolution at the ZWFS FPM
mp.wfs.mask.theta – The phase shift by the dimple. This is just for “convenience” when calling the reconstructor. For example, theta = 4*pi*depth/lam, is the theta value in reflective mode. 
 
ZWFS camera parameters
mp.wfs.cam.Nbeam - beam size at WFS camera
mp.wfs.cam.Narr - array size at WFS camera
mp.wfs.cam.dx – Use mp.P4.D/mp.wfs.cam.Nbeam for now. For simplicity, the beam diameter at the Lyot stop is currently used for the WFS pupil and scaled according to Nbeam.   
 
Models
falco_zwfs_sim_image – Simulates the image at the WFS camera
falco_zwfs_getReferenceWave – Simulates the so-called reference wave using falco_zwfs_sim_image. This is ‘b’ in the reconstructor.
falco_zwfs_getCalibrationImage – Simulates the calibration image using falco_zwfs_sim_image
model_ZWFS - called by falco_zwfs_sim_image at each wavelength. 
 
E-field as seen by WFS
mp.wfs.E is the E-field cube according to the WFS. It’s similar to mp.P1.full.E, but for the WFS wavelengths. Currently, the model_ZWFS will fill this in by extrapolating mp.P1.full.E assuming the amplitude is constant with wavelength and the phase errors are caused by surface errors (i.e. they scale with lambda0/lam). Other mp.wfs.E functions could be implemented later to explore other types of chromatic effects. 

