### PR TITLE
Adding falco_compute_psf_norm_factor back into falco_flesh_out_workspace 

### DIFF
--- a/lib/masks/falco_gen_SW_mask.m
+++ b/lib/masks/falco_gen_SW_mask.m
@@ -48,8 +48,8 @@ if(isfield(inputs,'etaOffset')); etaOffset = inputs.etaOffset; else; etaOffset =
 
 % minimum +/- field of view along both axes
 if isfield(inputs,'FOV'); FOV = inputs.FOV; else; FOV = inputs.rhoOuter; end
-if isfield(inputs,'xiFOV'); minFOVxi = inputs.xiFOV; else; minFOVxi = FOV + abs(xiOffset); end % minimum field of view along horizontal (xi) axis
-if isfield(inputs,'etaFOV'); minFOVeta = inputs.etaFOV; else; minFOVeta = FOV + abs(etaOffset); end % minimum field of view along vertical (eta) axis
+if isfield(inputs,'xiFOV'); minFOVxi = inputs.xiFOV; else; minFOVxi = FOV; end % minimum field of view along horizontal (xi) axis
+if isfield(inputs,'etaFOV'); minFOVeta = inputs.etaFOV; else; minFOVeta = FOV; end % minimum field of view along vertical (eta) axis
     
 if isfield(inputs,'centering'); centering = inputs.centering; else; centering = 'pixel'; end %--Default to pixel centering if it is not specified.
 

--- a/setup/falco_flesh_out_workspace.m
+++ b/setup/falco_flesh_out_workspace.m
@@ -39,6 +39,7 @@ mp = falco_gen_dm_stops(mp);
 mp = falco_set_dm_surface_padding(mp);
 
 mp = falco_set_initial_Efields(mp);
+mp = falco_compute_psf_norm_factor(mp);
 
 out = falco_init_storage_arrays(mp); % Initialize Arrays to Store Performance History
 

--- a/testing/testarchive/TestConfigureDarkHole.m
+++ b/testing/testarchive/TestConfigureDarkHole.m
@@ -77,14 +77,13 @@ classdef TestConfigureDarkHole < matlab.unittest.TestCase
             mp.Fend.corr.Rout  = [5, 5];  % outer radius of dark hole correction region [lambda0/D]
             mp.Fend.corr.ang  = [150, 180];  % angular opening of dark hole correction region [degrees]
             mp.Fend.score = mp.Fend.corr;
+            mp.Fend.FOV = 30;
             
             mp.centering = 'pixel';
             mp.Fend.sides = {'lr', 'lr'};
             mp.Fend.shape = {'circle', 'square'};
             mp.Fend.res = 10;
             mp.Fend.xiOffset = [0, 20];
-%             mp.Fend.xiFOV = 30;
-%             mp.Fend.etaFOV = 30;
             
             mp.Fend.eval.res = 20;
             mp.flagFiber = false;

--- a/testing/testarchive/TestGenSoftwareMask.m
+++ b/testing/testarchive/TestGenSoftwareMask.m
@@ -71,6 +71,7 @@ classdef TestGenSoftwareMask < matlab.unittest.TestCase
             inputs.pixresFP = 9;
             inputs.rhoInner = 2.5;
             inputs.rhoOuter = 10;
+            inputs.FOV = 15;
             inputs.angDeg = 160;
             inputs.whichSide = 't';
             inputs.centering = 'pixel';

--- a/testing/testarchive/TestPairwiseProbing.m
+++ b/testing/testarchive/TestPairwiseProbing.m
@@ -74,7 +74,6 @@ classdef TestPairwiseProbing < matlab.unittest.TestCase
             mp.P1.compact.mask = falco_gen_pupil_Simple(inputs); 
 
             [mp, out] = falco_flesh_out_workspace(mp);
-            mp = falco_compute_psf_norm_factor(mp);
             N = size(mp.P1.full.E, 1);
             alpha = 2.5;
             mirror_figure = 1e-9;

--- a/testing/tests_long/@ConfigurationMSWC/ConfigurationMSWC.m
+++ b/testing/tests_long/@ConfigurationMSWC/ConfigurationMSWC.m
@@ -114,7 +114,7 @@ mp.controller = 'gridsearchEFC';
 
 % % % GRID SEARCH EFC DEFAULTS     
 %--WFSC Iterations and Control Matrix Relinearization
-mp.Nitr = 3; %--Number of estimation+control iterations to perform
+mp.Nitr = 1; %--Number of estimation+control iterations to perform
 mp.relinItrVec = 1;%1:mp.Nitr;  %--Which correction iterations at which to re-compute the control Jacobian
 mp.dm_ind = [1 2]; %--Which DMs to use
 

--- a/testing/tests_long/TestFunctionalMSWC.m
+++ b/testing/tests_long/TestFunctionalMSWC.m
@@ -62,36 +62,30 @@ classdef TestFunctionalMSWC < matlab.unittest.TestCase
             end
             
             [mp, out] = falco_wfsc_loop(mp, out);
-            save('/Users/ajriggs/Downloads/out_file.mat', 'out')
 
             %% Tests:
-            Iraw = out.IrawCorrHist(end); % 7.8173e-07
-            testCase.verifyGreaterThan(Iraw, 7.7e-7)
-            testCase.verifyLessThan(Iraw, 7.9e-7)           
+            Iraw = out.IrawCorrHist(1); % 1.5640e-06
+            testCase.verifyGreaterThan(Iraw, 1.55e-6)
+            testCase.verifyLessThan(Iraw, 1.57e-6)           
             
-            Iest = out.IestScoreHist(end); % 1.1147e-07
-            testCase.verifyGreaterThan(Iest, 1.0e-7)
-            testCase.verifyLessThan(Iest, 1.2e-7)
+            Iest = out.IestScoreHist(1); % 3.4768e-07
+            testCase.verifyGreaterThan(Iest, 3.46e-7)
+            testCase.verifyLessThan(Iest, 3.49e-7)
             
-            Iinco = out.IincoCorrHist(end); % 1.7943e-06
-            testCase.verifyGreaterThan(Iinco, 1.75e-6)
-            testCase.verifyLessThan(Iinco, 1.8e-6)
-
-            import matlab.unittest.constraints.EveryElementOf
-            import matlab.unittest.constraints.IsGreaterThan
-            testCase.verifyThat(EveryElementOf(out.complexProjection(:)), IsGreaterThan(0.99))
+            Iinco = out.IincoCorrHist(1); % 2.7803e-6
+            testCase.verifyGreaterThan(Iinco, 2.77e-6)
+            testCase.verifyLessThan(Iinco, 2.79e-6)
             
-            dm1pv = out.dm1.Spv(end); % 1.8171e-08
-            testCase.verifyGreaterThan(dm1pv, 1.7e-8)
-            testCase.verifyLessThan(dm1pv, 1.9e-8)
+            dm1pv = out.dm1.Spv(1); % 5.5979e-09
+            testCase.verifyGreaterThan(dm1pv, 5.5e-9)
+            testCase.verifyLessThan(dm1pv, 5.7e-9)
             
-            thput = out.thput(end); % 0.2834
-            testCase.verifyGreaterThan(thput, 0.28)
-            testCase.verifyLessThan(thput, 0.29)
+            thput = out.thput(end); % 0.2843
+            testCase.verifyGreaterThan(thput, 0.2842)
+            testCase.verifyLessThan(thput, 0.2844)
             
-            import matlab.unittest.constraints.EveryElementOf
-            import matlab.unittest.constraints.IsEqualTo
-            testCase.verifyThat(EveryElementOf(out.log10regHist), IsEqualTo([-2])) % [-2; -2; -2]
+            testCase.verifyEqual(out.log10regHist(1), -2)
+            
         end       
     end    
 end

--- a/testing/tests_long/TestIntegrationJacobianFLC.m
+++ b/testing/tests_long/TestIntegrationJacobianFLC.m
@@ -34,7 +34,6 @@ classdef TestIntegrationJacobianFLC < matlab.unittest.TestCase
             %% Step 3: Perform the Wavefront Sensing and Control
             mp.runLabel = 'test_FLC';          
             [mp, out] = falco_flesh_out_workspace(mp);
-            mp = falco_compute_psf_norm_factor(mp);
             mp.dm1.V = zeros(mp.dm1.Nact);
             mp.dm2.V = zeros(mp.dm2.Nact);
             jacStruct = model_Jacobian(mp); %--Get structure containing Jacobians
@@ -94,7 +93,6 @@ classdef TestIntegrationJacobianFLC < matlab.unittest.TestCase
             mp.jac.minimizeNI = true;
             mp.runLabel = 'test_FLC';
             [mp, out] = falco_flesh_out_workspace(mp);
-            mp = falco_compute_psf_norm_factor(mp);
             
             mp.dm1.V = zeros(mp.dm1.Nact);
             mp.dm2.V = zeros(mp.dm2.Nact);

--- a/testing/tests_long/TestIntegrationJacobianLC.m
+++ b/testing/tests_long/TestIntegrationJacobianLC.m
@@ -32,7 +32,6 @@ classdef TestIntegrationJacobianLC < matlab.unittest.TestCase
             mp = testCase.mp;
             mp.runLabel = 'test_LC';
             [mp, out] = falco_flesh_out_workspace(mp);
-            mp = falco_compute_psf_norm_factor(mp);
             
             %% Fast Jacobian calculation
             mp.dm1.V = zeros(mp.dm1.Nact);
@@ -94,7 +93,6 @@ classdef TestIntegrationJacobianLC < matlab.unittest.TestCase
             mp.runLabel = 'test_LC';
             mp.propMethodPTP = 'mft';
             [mp, out] = falco_flesh_out_workspace(mp);
-            mp = falco_compute_psf_norm_factor(mp);
             
             %% Fast Jacobian calculation
             mp.dm1.V = zeros(mp.dm1.Nact);
@@ -157,7 +155,6 @@ classdef TestIntegrationJacobianLC < matlab.unittest.TestCase
             
             mp.runLabel = 'test_LC';
             [mp, out] = falco_flesh_out_workspace(mp);
-            mp = falco_compute_psf_norm_factor(mp);
             mp.dm1.V = zeros(mp.dm1.Nact);
             mp.dm2.V = zeros(mp.dm2.Nact);
 

--- a/testing/tests_long/TestIntegrationJacobianVortex.m
+++ b/testing/tests_long/TestIntegrationJacobianVortex.m
@@ -41,7 +41,6 @@ classdef TestIntegrationJacobianVortex < matlab.unittest.TestCase
             mp.runLabel = 'test_VC';
             mp.jac.mftToVortex = false;
             [mp, out] = falco_flesh_out_workspace(mp);
-            mp = falco_compute_psf_norm_factor(mp);
             
             %% Fast Jacobian calculation
             mp.dm1.V = zeros(mp.dm1.Nact);
@@ -118,7 +117,6 @@ classdef TestIntegrationJacobianVortex < matlab.unittest.TestCase
             mp.P4.compact.maskAtP1res = falco_gen_pupil_Simple(inputs);
             
             [mp, out] = falco_flesh_out_workspace(mp);
-            mp = falco_compute_psf_norm_factor(mp);
             
             %% Fast Jacobian calculation
             mp.dm1.V = zeros(mp.dm1.Nact);
@@ -181,7 +179,6 @@ classdef TestIntegrationJacobianVortex < matlab.unittest.TestCase
 
             mp.runLabel = 'test_VC';
             [mp, out] = falco_flesh_out_workspace(mp);
-            mp = falco_compute_psf_norm_factor(mp);
             mp.dm1.V = zeros(mp.dm1.Nact);
             mp.dm2.V = zeros(mp.dm2.Nact);
 


### PR DESCRIPTION
- To easy to forget to call `falco_compute_psf_norm_factor()` if it's not in `falco_flesh_out_workspace()`, so putting it back in.