### PR TITLE
Bug fix in two probing variable names

### DIFF
--- a/config/EXAMPLE_defaults_MSWC.m
+++ b/config/EXAMPLE_defaults_MSWC.m
@@ -1,4 +1,4 @@
-
+open 
 % %--Initialize some structures if they don't already exist
 
 %% Misc
@@ -48,8 +48,8 @@ mp.estimator = 'pwp-bp';
 %--New variables for pairwise probing estimation:
 mp.est.probe.Npairs = 2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
-mp.probe.est.width = [4, 4]; % Width of probed rectangular region. Units of lambda/D.
-mp.probe.est.height = [4, 4]; % Height of probed rectangular region. Units of lambda/D.
+mp.est.probe.width = [4, 4]; % Width of probed rectangular region. Units of lambda/D.
+mp.est.probe.height = [4, 4]; % Height of probed rectangular region. Units of lambda/D.
 mp.est.probe.xiOffset = [6, 6]; % xi (horizontal) offset of probed region's center in focal plane. Units of lambda/D.
 mp.est.probe.etaOffset = [0, 6]; % eta (horizontal) offset of probed region's center in focal plane. Units of lambda/D.
 mp.est.probe.xOffset = 0;   % offset of probe center in x at DM [actuators]. Use to avoid central obscurations.

--- a/lib/wfsc/falco_gen_pairwise_probe.m
+++ b/lib/wfsc/falco_gen_pairwise_probe.m
@@ -29,8 +29,8 @@
 % in focal plane. Units of lambda/D.
 % mp.est.probe.etaOffset : eta (horizontal) offset of probed region's
 % center in focal plane. Units of lambda/D.
-% mp.probe.est.width : Width of probed rectangular region. Units of lambda/D.
-% mp.probe.est.height : Height of probed rectangular region. Units of lambda/D. 
+% mp.est.probe.width : Width of probed rectangular region. Units of lambda/D.
+% mp.est.probe.height : Height of probed rectangular region. Units of lambda/D. 
 %
 % RETURNS
 % -------
@@ -60,8 +60,8 @@ ys = (-(Nact-1)/2:(Nact-1)/2)/Nact - round(mp.est.probe.yOffset)/Nact;
 lamDIntoAct = Nact / NactPerBeam;
 xiOffset = mp.est.probe.xiOffset(starIndex) * lamDIntoAct; 
 etaOffset = mp.est.probe.etaOffset(starIndex) * lamDIntoAct;
-width = mp.probe.est.width(starIndex) * lamDIntoAct;
-height = mp.probe.est.height(starIndex) * lamDIntoAct;
+width = mp.est.probe.width(starIndex) * lamDIntoAct;
+height = mp.est.probe.height(starIndex) * lamDIntoAct;
 
 maxSpatialFreq = Nact / 2;
 if (xiOffset + width/2) > maxSpatialFreq || (etaOffset + height/2) > maxSpatialFreq

--- a/testing/tests_long/@ConfigurationMSWC/ConfigurationMSWC.m
+++ b/testing/tests_long/@ConfigurationMSWC/ConfigurationMSWC.m
@@ -64,8 +64,8 @@ mp.estimator = 'pwp-bp';
 %--New variables for pairwise probing estimation:
 mp.est.probe.Npairs = 2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
-mp.probe.est.width = [4, 4]; % Width of probed rectangular region. Units of lambda/D.
-mp.probe.est.height = [4, 4]; % Height of probed rectangular region. Units of lambda/D.
+mp.est.probe.width = [4, 4]; % Width of probed rectangular region. Units of lambda/D.
+mp.est.probe.height = [4, 4]; % Height of probed rectangular region. Units of lambda/D.
 mp.est.probe.xiOffset = [6, 6]; % xi (horizontal) offset of probed region's center in focal plane. Units of lambda/D.
 mp.est.probe.etaOffset = [0, 6]; % eta (horizontal) offset of probed region's center in focal plane. Units of lambda/D.
 mp.est.probe.xOffset = 0;   % offset of probe center in x at DM [actuators]. Use to avoid central obscurations.


### PR DESCRIPTION
mp.probe.est.width --> mp.est.probe.width
mp.probe.est.height --> mp.est.probe.height