### PR TITLE
Including several new phase mask types for FPMs

### DIFF
--- a/demo/demo_gen_SW_mask.m
+++ b/demo/demo_gen_SW_mask.m
@@ -61,11 +61,11 @@ inputs.FOV = 15;
 inputs.whichSide = 'ud';
 inputs.shape = 'rectangle';
 
-[mask5, xis5, etas5] = falco_gen_SW_mask(inputs);
-figure(5); imagesc(xis5, etas5, mask5); axis xy equal tight; colormap gray; drawnow;
+[mask4, xis4, etas4] = falco_gen_SW_mask(inputs);
+figure(4); imagesc(xis4, etas4, mask4); axis xy equal tight; colormap gray; drawnow;
 
 
-% Check shifting the pupil and having a rectangular array. 
+% Check shifting the mask and having a rectangular array. 
 inputs.xiFOV = 30;
 inputs.etaFOV = 11;
 inputs.xiOffset = 10;
@@ -75,5 +75,23 @@ inputs.clockAngDeg = 0;
 inputs.whichSide = 't';
 inputs.shape = 'square';
 
-[mask4, xis4, etas4] = falco_gen_SW_mask(inputs);
-figure(4); imagesc(xis4, etas4, mask4); axis xy equal tight; colormap gray; drawnow;
+[mask5, xis5, etas5] = falco_gen_SW_mask(inputs);
+figure(5); imagesc(xis5, etas5, mask5); axis xy equal tight; colormap gray; drawnow;
+
+
+% Check making a square offset from the star 
+clear inputs
+inputs.pixresFP = 9;
+inputs.rhoInner = 0;
+inputs.rhoOuter = 2.5;
+inputs.xiFOV = 16;
+inputs.etaFOV = 20;
+inputs.xiOffset = 4;
+inputs.etaOffset = 0;
+inputs.angDeg = 180;
+inputs.clockAngDeg = 0;
+inputs.whichSide = 'lr';
+inputs.shape = 'square';
+
+[mask6, xis6, etas6] = falco_gen_SW_mask(inputs);
+figure(6); imagesc(xis6, etas6, mask6); axis xy equal tight; colormap gray; drawnow;

--- a/demo/demo_gen_azimuthal_phase_masks.m
+++ b/demo/demo_gen_azimuthal_phase_masks.m
@@ -9,7 +9,7 @@
 
 clear
 
-inputs.type = 'staircase';  % 'vortex', 'cos', 'sectors', and 'staircase.'
+inputs.type = 'staircase';  % Options are 'vortex', 'cos', 'sectors', and 'staircase'.
 inputs.N = 200; % pixels across the 
 inputs.charge = 4; % charge of the mask (makes most sense for vortex)
 inputs.Nsteps = 6; % number of steps per 2*pi radians. For 'staircase' only

--- a/demo/demo_gen_azimuthal_phase_masks.m
+++ b/demo/demo_gen_azimuthal_phase_masks.m
@@ -1,0 +1,63 @@
+% Copyright 2018-2021, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+%
+% Demonstrate all the options for falco_gen_azimuthal_phase_mask()
+%
+
+clear
+
+inputs.type = 'staircase';  % 'vortex', 'cos', 'sectors', and 'staircase.'
+inputs.N = 200; % pixels across the 
+inputs.charge = 4; % charge of the mask (makes most sense for vortex)
+inputs.Nsteps = 6; % number of steps per 2*pi radians. For 'staircase' only
+
+%--Optional Inputs
+% inputs.centering = 'pixel';
+% inputs.xOffset = 5.5; % [pixels]
+% inputs.yOffset = -10; % [pixels]
+% inputs.clocking = 0; % [degrees]
+
+% Check staircase
+mask = falco_gen_azimuthal_phase_mask(inputs);
+figure(1); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;
+
+% Check clocking
+inputs.clocking = 30; % [degrees]
+mask = falco_gen_azimuthal_phase_mask(inputs);
+figure(2); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;
+
+% Check lateral offsets and rotation together
+inputs.clocking = 30; % [degrees]
+inputs.xOffset = 30.2; % [pixels]
+inputs.yOffset = -14.5; % [pixels]
+mask = falco_gen_azimuthal_phase_mask(inputs);
+figure(3); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;
+
+%%
+clear inputs
+
+% Check vortex
+inputs.type = 'vortex';  % 'vortex', 'cos', 'sectors', and 'staircase.'
+inputs.N = 200; % pixels across the 
+inputs.charge = 6; % charge of the mask (makes most sense for vortex)
+mask = falco_gen_azimuthal_phase_mask(inputs);
+figure(4); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;
+
+% Check sectors
+inputs.type = 'sectors';  % 'vortex', 'cos', 'sectors', and 'staircase.'
+mask = falco_gen_azimuthal_phase_mask(inputs);
+figure(5); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;
+
+% Check cos
+inputs.type = 'cos';  % 'vortex', 'cos', 'sectors', and 'staircase.'
+mask = falco_gen_azimuthal_phase_mask(inputs);
+figure(6); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;
+
+% Check rotated cos
+inputs.clocking = 30; % [degrees]
+inputs.type = 'cos';  % 'vortex', 'cos', 'sectors', and 'staircase.'
+mask = falco_gen_azimuthal_phase_mask(inputs);
+figure(7); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;

--- a/demo/demo_gen_azimuthal_phase_masks.m
+++ b/demo/demo_gen_azimuthal_phase_masks.m
@@ -9,12 +9,14 @@
 
 clear
 
+% Required Inputs
 inputs.type = 'staircase';  % Options are 'vortex', 'cos', 'sectors', and 'staircase'.
 inputs.N = 200; % pixels across the 
 inputs.charge = 4; % charge of the mask (makes most sense for vortex)
 inputs.Nsteps = 6; % number of steps per 2*pi radians. For 'staircase' only
+inputs.phaseScaleFac = 1; % Factor to apply uniformly to the phase. Used to add chromaticity.
 
-%--Optional Inputs
+% % Optional Inputs
 % inputs.centering = 'pixel';
 % inputs.xOffset = 5.5; % [pixels]
 % inputs.yOffset = -10; % [pixels]
@@ -36,6 +38,11 @@ inputs.yOffset = -14.5; % [pixels]
 mask = falco_gen_azimuthal_phase_mask(inputs);
 figure(3); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;
 
+% Generate staircase with PROPER to get non-binary edges
+phase = falco_gen_spiral_staircase(inputs);
+mask = exp(1j*phase);
+figure(13); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;
+
 %%
 clear inputs
 
@@ -43,6 +50,7 @@ clear inputs
 inputs.type = 'vortex';  % 'vortex', 'cos', 'sectors', and 'staircase.'
 inputs.N = 200; % pixels across the 
 inputs.charge = 6; % charge of the mask (makes most sense for vortex)
+inputs.phaseScaleFac = 1; % Factor to apply uniformly to the phase. Used to add chromaticity.
 mask = falco_gen_azimuthal_phase_mask(inputs);
 figure(4); imagesc(angle(mask)); axis xy equal tight; colorbar; colormap gray; drawnow;
 

--- a/lib/check/check_scalar_integer.m
+++ b/lib/check/check_scalar_integer.m
@@ -1,0 +1,39 @@
+% Copyright 2018-2021, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+%
+% Check if a variable is an real-valued scalar integer.
+%
+% INPUTS
+% x: variable to check
+%
+% OUTPUTS
+% -------
+% None
+%
+
+function check_scalar_integer(x)
+    
+    if ~isnumeric(x)
+        error('input value is not numeric')
+    end
+    
+    if ~numel(x) == 1
+        error('input is not a scalar')
+    end
+    
+    if isinf(x)
+        error('input is infinite')
+    end
+    
+    if ~isreal(x)
+        error('input is not real-valued')
+    end
+    
+    if x ~= floor(x)
+        error('input is not a integer')
+    end
+    
+end %--END OF FUNCTION

--- a/lib/masks/falco_gen_azimuthal_phase_mask.m
+++ b/lib/masks/falco_gen_azimuthal_phase_mask.m
@@ -85,6 +85,7 @@ function mask = falco_gen_azimuthal_phase_mask(inputs)
         case 'staircase'
             Nsteps = inputs.Nsteps;
             mask = exp(1j*ceil(mod((THETA+pi)/(2*pi)*charge, 1)*Nsteps)/Nsteps*2*pi);
+%             mask = exp(1j*falco_gen_spiral_staircase(inputs));
 
         otherwise
             validOptions = "Valid options are 'vortex', 'cos', 'sectors', and 'staircase.";

--- a/lib/masks/falco_gen_azimuthal_phase_mask.m
+++ b/lib/masks/falco_gen_azimuthal_phase_mask.m
@@ -1,0 +1,94 @@
+% Copyright 2018-2020, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+% function OUT = propcustom_mft_PtoFtoP(IN, FPM, charge, apRad, inVal, outVal, useGPU ) 
+%
+% Generate a 
+%
+% FPM must be an array with dimensions MxM, where M = lambdaOverD*(beam diameter)
+%
+% INPUTS
+% ------
+% inputs: structure of inputs parameters
+%   - inputs.type: type of mask. Valid options are 'vortex', 'cos',
+%   'sectors', and 'staircase.'
+%   - inputs.charge: number of 2-pi phase progressions over the 360
+%     degrees of the mask)
+%   - inputs.N: width and height of the output array
+%   - inputs.Nsteps: (required for 'staircase') number of steps per
+%                    2*pi radians in the staircase
+%   - inputs.clocking: (optional) clocking of the phase mask in degrees
+%   - inputs.centering: (optional) array centering of the mask
+%   - inputs.xOffset: (optional) x-offset of the mask center from the
+%                     array center in units of pixels
+%   - inputs.yOffset: (optional) y-offset of the mask center from the
+%                     array center in units of pixels
+%
+% OUTPUTS
+% -------
+% OUT: 2-D, NxN array with complex transmission of the mask 
+
+function mask = falco_gen_azimuthal_phase_mask(inputs)
+
+    % Required inputs
+    maskType = inputs.type; 
+    charge = inputs.charge; 
+    N = inputs.N; 
+
+    % OPTIONAL INPUTS
+    centering = 'pixel';  %--Default to pixel centering
+    xOffset = 0;
+    yOffset = 0;
+    clocking = 0; % [degrees]
+    if(isfield(inputs,'centering')); centering = inputs.centering; end % 'pixel' or 'interpixel'
+    if(isfield(inputs, 'xOffset')); xOffset = inputs.xOffset; end % [pixels]
+    if(isfield(inputs, 'yOffset')); yOffset = inputs.yOffset; end % [pixels]
+    if(isfield(inputs,'clocking')); clocking = inputs.clocking; end % [degrees]
+
+    % make coordinate system 
+    if strcmpi(centering, 'pixel')
+        xs = -N/2:(N/2-1);
+    elseif strcmpi(centering, 'interpixel')
+        xs = -(N-1)/2:(N-1)/2;
+    else
+        error('Invalid option for inputs.centering')
+    end
+    [X, Y] = meshgrid(xs);
+    
+    X = X - xOffset;
+    Y = Y - yOffset;
+    
+    % rotate all points before computing THETA
+    xyAll = [reshape(X, [1, N*N]); reshape(Y, [1, N*N])];
+    rotMat = [cosd(clocking), sind(clocking); -sind(clocking), cosd(clocking)];
+    xyAll = rotMat * xyAll;
+    X = reshape(xyAll(1, :), [N, N]);
+    Y = reshape(xyAll(2, :), [N, N]);
+
+    [THETA, ~] = cart2pol(X, Y);
+
+    % make mask 
+    switch lower(maskType)
+        case 'vortex'
+            mask = exp(1j*charge*THETA);
+
+        case{'cos'}
+            z_m = besselzero(0,1);
+            z_m = z_m(end);
+            mask = exp(1j*z_m*cos(charge*THETA));
+
+        case 'sectors'
+            mask = exp(1j*pi/2*sign(cos(charge*THETA)));
+
+        case 'staircase'
+            Nsteps = inputs.Nsteps;
+            mask = exp(1j*ceil(mod((THETA+pi)/(2*pi)*charge, 1)*Nsteps)/Nsteps*2*pi);
+
+        otherwise
+            error('%s not a valid option for inputs.type.', inputs.type)
+    end
+
+end
+

--- a/lib/masks/falco_gen_azimuthal_phase_mask.m
+++ b/lib/masks/falco_gen_azimuthal_phase_mask.m
@@ -1,4 +1,4 @@
-% Copyright 2018-2020, by the California Institute of Technology. ALL RIGHTS
+% Copyright 2018-2021, by the California Institute of Technology. ALL RIGHTS
 % RESERVED. United States Government Sponsorship acknowledged. Any
 % commercial use must be negotiated with the Office of Technology Transfer
 % at the California Institute of Technology.
@@ -35,7 +35,7 @@ function mask = falco_gen_azimuthal_phase_mask(inputs)
     % Required inputs
     maskType = inputs.type; 
     charge = inputs.charge; 
-    N = inputs.N; 
+    N = inputs.N;
 
     % OPTIONAL INPUTS
     centering = 'pixel';  %--Default to pixel centering
@@ -87,7 +87,8 @@ function mask = falco_gen_azimuthal_phase_mask(inputs)
             mask = exp(1j*ceil(mod((THETA+pi)/(2*pi)*charge, 1)*Nsteps)/Nsteps*2*pi);
 
         otherwise
-            error('%s not a valid option for inputs.type.', inputs.type)
+            validOptions = "Valid options are 'vortex', 'cos', 'sectors', and 'staircase.";
+            error('%s is not a valid option for inputs.type. \n%s', inputs.type, validOptions)
     end
 
 end

--- a/lib/masks/falco_gen_spiral_staircase.m
+++ b/lib/masks/falco_gen_spiral_staircase.m
@@ -16,6 +16,8 @@
 %   - inputs.charge: number of 2-pi phase progressions over the 360
 %     degrees of the mask). Must be an integer.
 %   - inputs.N: width and height of the output array
+%   - inputs.phaseScaleFac: Factor to apply uniformly to the phase.
+%                           Used to add chromaticity.
 %   - inputs.Nsteps: (required for 'staircase') number of steps per
 %                    2*pi radians in the staircase
 %   - inputs.clocking: (optional) clocking of the phase mask in degrees
@@ -34,7 +36,8 @@ function mask = falco_gen_spiral_staircase(inputs)
     % Required inputs
     NarrayFinal = inputs.N;
     Nsteps = inputs.Nsteps;
-    charge = inputs.charge; 
+    charge = inputs.charge;
+    phaseScaleFac = inputs.phaseScaleFac;
 
     % OPTIONAL INPUTS
     centering = 'pixel';  %--Default to pixel centering
@@ -91,6 +94,8 @@ function mask = falco_gen_spiral_staircase(inputs)
     end
 
     mask = mask - (2*pi)/Nsteps; % Set minimum to zero.
+    
+    mask = mask * phaseScaleFac;
 
     mask = pad_crop(mask, NarrayFinal);
 

--- a/lib/masks/falco_gen_spiral_staircase.m
+++ b/lib/masks/falco_gen_spiral_staircase.m
@@ -1,0 +1,97 @@
+% -------------------------------------------------------------------------
+% Copyright 2018-2021, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+% function mask = falco_gen_spiral_staircase(inputs)
+% 
+% Generate a spiral staircase pattern.
+%
+% FPM must be an array with dimensions MxM, where M = lambdaOverD*(beam diameter)
+%
+% INPUTS
+% ------
+% inputs: structure of inputs parameters
+%   - inputs.charge: number of 2-pi phase progressions over the 360
+%     degrees of the mask). Must be an integer.
+%   - inputs.N: width and height of the output array
+%   - inputs.Nsteps: (required for 'staircase') number of steps per
+%                    2*pi radians in the staircase
+%   - inputs.clocking: (optional) clocking of the phase mask in degrees
+%   - inputs.centering: (optional) array centering of the mask
+%   - inputs.xOffset: (optional) x-offset of the mask center from the
+%                     array center in units of pixels
+%   - inputs.yOffset: (optional) y-offset of the mask center from the
+%                     array center in units of pixels
+%
+% OUTPUTS
+% -------
+% OUT: 2-D, NxN array with complex transmission of the mask 
+
+function mask = falco_gen_spiral_staircase(inputs)
+
+    % Required inputs
+    NarrayFinal = inputs.N;
+    Nsteps = inputs.Nsteps;
+    charge = inputs.charge; 
+
+    % OPTIONAL INPUTS
+    centering = 'pixel';  %--Default to pixel centering
+    xOffset = 0;
+    yOffset = 0;
+    clocking = 0; % [degrees]
+    if(isfield(inputs,'centering')); centering = inputs.centering; end % 'pixel' or 'interpixel'
+    if(isfield(inputs, 'xOffset')); xOffset = inputs.xOffset; end % [pixels]
+    if(isfield(inputs, 'yOffset')); yOffset = inputs.yOffset; end % [pixels]
+    if(isfield(inputs,'clocking')); clocking = inputs.clocking; end % [degrees]
+
+    % Input checks
+    check_scalar_integer(charge);
+    
+    % minimum radius  of circle centered at (x, y) = (xOffset, yOffset) to contain the full array.
+    maxOffset = max(abs(xOffset), abs(yOffset));
+    R = 2*NarrayFinal + maxOffset + 1;
+    Narray = ceil_even(2*(R+maxOffset) + 2); % Temporary width of array.
+
+    % Set up PROPER
+    Dbeam = Narray; %--diameter of beam (normalized to itself)
+    dx = Dbeam/Narray;
+    Darray = Narray*dx;
+    wl_dummy = 1e-6; %--dummy value
+    bdf = Dbeam/Darray; %--beam diameter fraction
+    wavestruct = prop_begin(Dbeam, wl_dummy, Narray, 'beam_diam_fraction', bdf);
+
+    switch centering
+        case {'interpixel'}
+            cshift = -dx/2; 
+        case {'pixel'}
+            cshift = 0;
+    end
+
+    deltaThetaStep = 360/charge/Nsteps; % [degrees]
+    deltaThetaSector = 360/charge; 
+    mask = zeros(Narray);
+    for iSector = 1:charge
+        for iStep = Nsteps:-1:1
+            theta0 = clocking + (iSector-1)*deltaThetaSector - deltaThetaStep;
+            xyCorners = [0, R*cosd(theta0), R*cosd(theta0-iStep*deltaThetaStep), 0;
+                         0, R*sind(theta0), R*sind(theta0-iStep*deltaThetaStep), 0];
+
+            % Translate
+            xyCorners =  xyCorners + cshift;
+            xs = xyCorners(1, :) + xOffset;
+            ys = xyCorners(2, :) + yOffset;
+
+            % Add next step
+            maskNew = (2*pi)/Nsteps*(prop_irregular_polygon(wavestruct, xs, ys));
+            mask = mask + maskNew;
+
+        end
+    end
+
+    mask = mask - (2*pi)/Nsteps; % Set minimum to zero.
+
+    mask = pad_crop(mask, NarrayFinal);
+
+end

--- a/lib/propcustom/propcustom_mft_PtoFtoP.m
+++ b/lib/propcustom/propcustom_mft_PtoFtoP.m
@@ -6,10 +6,12 @@
 %
 % function OUT = propcustom_mft_PtoFtoP(IN, FPM, charge, apRad, inVal, outVal, useGPU ) 
 %
-% Propagate from the pupil plane before a FPM to the
-% pupil plane after it.
+% Propagate from the pupil plane before a FPM to the pupil plane after it.
 %
 % FPM must be an array with dimensions MxM, where M = lambdaOverD*(beam diameter)
+%
+% Optional arguments allow for an opaque spot to be placed on the mask to
+% block the phase singularity. The spot can also be offset from the mask center.
 %
 % INPUTS
 % ------
@@ -21,6 +23,9 @@
 % outVal: radial separation in lambda/D at which to end the Tukey window
 %         transition between coarse and fine resolution.
 % useGPU: boolean flag whether to use a GPU to speed up calculations
+% diamSpotLamD: (optional) diameter of the opaque spot in lambda0/D.
+% offsetsLamD: (optional) the (x, y) offsets of the opaque spot from the
+%              mask center in units of lambda0/D.
 %
 % OUTPUTS
 % -------
@@ -35,7 +40,19 @@
 % 2. The sampling of the coarse DFT is set as the width of the FPM array
 %    divided by the beam diameter in pixels.
 
-function OUT = propcustom_mft_PtoFtoP(IN, FPM, apRad, inVal, outVal, useGPU)
+function OUT = propcustom_mft_PtoFtoP(IN, FPM, apRad, inVal, outVal, useGPU, varargin)
+
+    % Optional arguments
+    diamSpotLamD = 0; % Spot diameter [lambda0/D]
+    offsetsLamD = [0, 0]; % (x, y) offsets of spot [lambda0/D]
+    if length(varargin) == 1
+        diamSpotLamD = varargin{1};
+    elseif length(varargin) == 2
+        diamSpotLamD = varargin{1};
+        offsetsLamD = varargin{2};
+    elseif length(varargin) > 1
+        error('Too many inputs.')
+    end
 
     showPlots2debug = false; 
 
@@ -68,18 +85,49 @@ function OUT = propcustom_mft_PtoFtoP(IN, FPM, apRad, inVal, outVal, useGPU)
 
     if showPlots2debug; figure; imagesc(abs(IN)); axis image; colorbar; title('pupil'); end
 
-    % Full FOV, lower sampling DFT
+    %% Full FOV, lower resolution DFT
+    
+    % Generate low-resolution central opaque spot
+    if diamSpotLamD > 0
+        inputs.pixresFPM = pixres; %--pixels per lambda/D
+        inputs.rhoInner = diamSpotLamD/2; % radius of inner FPM amplitude spot (in lambda_c/D)
+        inputs.rhoOuter = inf; % radius of outer opaque FPM ring (in lambda_c/D)
+        inputs.FPMampFac = 0; % amplitude transmission of inner FPM spot
+        inputs.centering = 'pixel';
+        inputs.xOffset = offsetsLamD(1);
+        inputs.yOffset = offsetsLamD(2);
+        spotCoarse = falco_gen_annular_FPM(inputs);
+        spotCoarse = pad_crop(spotCoarse, NB, 'extrapval', 1);
+    else
+        spotCoarse = 1;
+    end
+    
     FP1 = 1/(1*D*pixPerLamD)*exp(-1i*2*pi*u1'*x)*IN*exp(-1i*2*pi*x'*u1); 
     if showPlots2debug; figure; imagesc(log10(abs(FP1).^2)); axis image; colorbar; title('Large scale DFT'); end
 
-    LP1 = 1/(1*D*pixPerLamD)*exp(-1i*2*pi*x'*u1)*(FP1.*FPM.*(1-windowMASK1))*exp(-1i*2*pi*u1'*x);
+    LP1 = 1/(1*D*pixPerLamD)*exp(-1i*2*pi*x'*u1)*(FP1.*spotCoarse.*FPM.*(1-windowMASK1))*exp(-1i*2*pi*u1'*x);
     if showPlots2debug; figure; imagesc(abs(FP1.*(1-windowMASK1))); axis image; colorbar; title('Large scale DFT (windowed)'); end
     
-    % Smaller FOV, finer sampling DFT
+    %% Smaller FOV, finer sampling DFT
+    
+    % Generate high-resolution central opaque spot
+    if diamSpotLamD > 0
+        inputs.pixresFPM = NB/(2*outVal); %--pixels per lambda/D
+        inputs.rhoInner = diamSpotLamD/2; % radius of inner FPM amplitude spot (in lambda_c/D)
+        inputs.rhoOuter = inf; % radius of outer opaque FPM ring (in lambda_c/D)
+        inputs.FPMampFac = 0; % amplitude transmission of inner FPM spot
+        inputs.centering = 'pixel';
+        inputs.xOffset = offsetsLamD(1);
+        inputs.yOffset = offsetsLamD(2);
+        spotFine = falco_gen_annular_FPM(inputs);
+        spotFine = pad_crop(spotFine, NB, 'extrapval', 1);
+    else
+        spotFine = 1;
+    end
     FP2 = 2*outVal/(1*D*NB)*exp(-1i*2*pi*u2'*x)*IN*exp(-1i*2*pi*x'*u2); 
     if showPlots2debug; figure; imagesc(log10(abs(FP2).^2)); axis image; colorbar; title('Fine sampled DFT'); end
 
-    LP2 = 2*outVal/(1*D*NB)*exp(-1i*2*pi*x'*u2)*(FP2.*FPM.*windowMASK2)*exp(-1i*2*pi*u2'*x);        
+    LP2 = 2*outVal/(1*D*NB)*exp(-1i*2*pi*x'*u2)*(FP2.*spotFine.*FPM.*windowMASK2)*exp(-1i*2*pi*u2'*x);        
     if showPlots2debug; figure; imagesc(abs(FP2.*windowMASK2)); axis image; colorbar; title('Fine sampled DFT (windowed)'); end
     OUT = LP1 + LP2;
     if showPlots2debug; figure; imagesc(abs(OUT)); axis image; colorbar; title('Lyot plane'); end

--- a/lib/propcustom/propcustom_mft_PtoFtoP.m
+++ b/lib/propcustom/propcustom_mft_PtoFtoP.m
@@ -15,7 +15,7 @@
 % ------
 % IN: 2-D E-field at the pupil from which to propagate
 % FPM: 2-D, complex-valued array representing the FPM to use.
-% apRad: radius of the beam at the starting pupil
+% apRad: radius of the beam at the starting pupil. Units of pixels.
 % inVal: radial separation in lambda/D at which to start the Tukey window
 %        transition between coarse and fine resolution.
 % outVal: radial separation in lambda/D at which to end the Tukey window
@@ -29,33 +29,32 @@
 %
 % WARNINGS
 % --------
-% 1. Use this only with infinite-extent focal plane masks. (That is,
-%    with no outer cutoff within the field of view of the array.)
-% 2. Use this only with azimuthal-only masks. Radial variation will cause
+% 1. Use this only with azimuthal-only masks. Radial variation will cause
 %    problems because the same FPM array is used at both the coarse and
 %    fine resolutions.
+% 2. The sampling of the coarse DFT is set as the width of the FPM array
+%    divided by the beam diameter in pixels.
 
-function OUT = propcustom_mft_PtoFtoP(IN, FPM, apRad, inVal, outVal, useGPU )
+function OUT = propcustom_mft_PtoFtoP(IN, FPM, apRad, inVal, outVal, useGPU)
 
     showPlots2debug = false; 
 
-    D = 2*apRad;
-    lambdaOverD = 4; % [samples per lambda/D]
-    
+    D = 2*apRad;    
     [NA, ~] = size(IN);
-    NB = lambdaOverD*D; 
+    NB = size(FPM, 1);
+    pixPerLamD = NB/D; % [samples per lambda/D at coarse resolution]
     
     [X,Y] = meshgrid(-NB/2:NB/2-1);
     RHO = sqrt(X.^2 + Y.^2);
    
     windowKnee = 1-inVal/outVal;
     
-    windowMASK1 = falco_gen_Tukey4vortex(2*outVal*lambdaOverD, RHO, windowKnee) ;
+    windowMASK1 = falco_gen_Tukey4vortex(2*outVal*pixPerLamD, RHO, windowKnee) ;
     windowMASK2 = falco_gen_Tukey4vortex(NB, RHO, windowKnee) ;
 
     % DFT vectors 
     x = (-NA/2:NA/2-1)/D;
-    u1 = (-NB/2:NB/2-1)/lambdaOverD;
+    u1 = (-NB/2:NB/2-1)/pixPerLamD;
     u2 = (-NB/2:NB/2-1)*2*outVal/NB;
         
     if useGPU
@@ -70,10 +69,10 @@ function OUT = propcustom_mft_PtoFtoP(IN, FPM, apRad, inVal, outVal, useGPU )
     if showPlots2debug; figure; imagesc(abs(IN)); axis image; colorbar; title('pupil'); end
 
     % Full FOV, lower sampling DFT
-    FP1 = 1/(1*D*lambdaOverD)*exp(-1i*2*pi*u1'*x)*IN*exp(-1i*2*pi*x'*u1); 
+    FP1 = 1/(1*D*pixPerLamD)*exp(-1i*2*pi*u1'*x)*IN*exp(-1i*2*pi*x'*u1); 
     if showPlots2debug; figure; imagesc(log10(abs(FP1).^2)); axis image; colorbar; title('Large scale DFT'); end
 
-    LP1 = 1/(1*D*lambdaOverD)*exp(-1i*2*pi*x'*u1)*(FP1.*FPM.*(1-windowMASK1))*exp(-1i*2*pi*u1'*x);
+    LP1 = 1/(1*D*pixPerLamD)*exp(-1i*2*pi*x'*u1)*(FP1.*FPM.*(1-windowMASK1))*exp(-1i*2*pi*u1'*x);
     if showPlots2debug; figure; imagesc(abs(FP1.*(1-windowMASK1))); axis image; colorbar; title('Large scale DFT (windowed)'); end
     
     % Smaller FOV, finer sampling DFT

--- a/lib/propcustom/propcustom_mft_PtoFtoP.m
+++ b/lib/propcustom/propcustom_mft_PtoFtoP.m
@@ -1,0 +1,92 @@
+% Copyright 2018-2021, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+%
+% function OUT = propcustom_mft_PtoFtoP(IN, FPM, charge, apRad, inVal, outVal, useGPU ) 
+%
+% Propagate from the pupil plane before a FPM to the
+% pupil plane after it.
+%
+% FPM must be an array with dimensions MxM, where M = lambdaOverD*(beam diameter)
+%
+% INPUTS
+% ------
+% IN: 2-D E-field at the pupil from which to propagate
+% FPM: 2-D, complex-valued array representing the FPM to use.
+% apRad: radius of the beam at the starting pupil
+% inVal: radial separation in lambda/D at which to start the Tukey window
+%        transition between coarse and fine resolution.
+% outVal: radial separation in lambda/D at which to end the Tukey window
+%         transition between coarse and fine resolution.
+% useGPU: boolean flag whether to use a GPU to speed up calculations
+%
+% OUTPUTS
+% -------
+% OUT: 2-D E-field at the next pupil plane after propagating through the
+%      FPM.
+%
+% WARNINGS
+% --------
+% 1. Use this only with infinite-extent focal plane masks. (That is,
+%    with no outer cutoff within the field of view of the array.)
+% 2. Use this only with azimuthal-only masks. Radial variation will cause
+%    problems because the same FPM array is used at both the coarse and
+%    fine resolutions.
+
+function OUT = propcustom_mft_PtoFtoP(IN, FPM, apRad, inVal, outVal, useGPU )
+
+    showPlots2debug = false; 
+
+    D = 2*apRad;
+    lambdaOverD = 4; % [samples per lambda/D]
+    
+    [NA, ~] = size(IN);
+    NB = lambdaOverD*D; 
+    
+    [X,Y] = meshgrid(-NB/2:NB/2-1);
+    RHO = sqrt(X.^2 + Y.^2);
+   
+    windowKnee = 1-inVal/outVal;
+    
+    windowMASK1 = falco_gen_Tukey4vortex(2*outVal*lambdaOverD, RHO, windowKnee) ;
+    windowMASK2 = falco_gen_Tukey4vortex(NB, RHO, windowKnee) ;
+
+    % DFT vectors 
+    x = (-NA/2:NA/2-1)/D;
+    u1 = (-NB/2:NB/2-1)/lambdaOverD;
+    u2 = (-NB/2:NB/2-1)*2*outVal/NB;
+        
+    if useGPU
+        IN = gpuArray(IN);
+        x = gpuArray(x);
+        u1 = gpuArray(u1);
+        u2 = gpuArray(u2);
+        windowMASK1 = gpuArray(windowMASK1);
+        windowMASK2 = gpuArray(windowMASK2);
+    end
+
+    if showPlots2debug; figure; imagesc(abs(IN)); axis image; colorbar; title('pupil'); end
+
+    % Full FOV, lower sampling DFT
+    FP1 = 1/(1*D*lambdaOverD)*exp(-1i*2*pi*u1'*x)*IN*exp(-1i*2*pi*x'*u1); 
+    if showPlots2debug; figure; imagesc(log10(abs(FP1).^2)); axis image; colorbar; title('Large scale DFT'); end
+
+    LP1 = 1/(1*D*lambdaOverD)*exp(-1i*2*pi*x'*u1)*(FP1.*FPM.*(1-windowMASK1))*exp(-1i*2*pi*u1'*x);
+    if showPlots2debug; figure; imagesc(abs(FP1.*(1-windowMASK1))); axis image; colorbar; title('Large scale DFT (windowed)'); end
+    
+    % Smaller FOV, finer sampling DFT
+    FP2 = 2*outVal/(1*D*NB)*exp(-1i*2*pi*u2'*x)*IN*exp(-1i*2*pi*x'*u2); 
+    if showPlots2debug; figure; imagesc(log10(abs(FP2).^2)); axis image; colorbar; title('Fine sampled DFT'); end
+
+    LP2 = 2*outVal/(1*D*NB)*exp(-1i*2*pi*x'*u2)*(FP2.*FPM.*windowMASK2)*exp(-1i*2*pi*u2'*x);        
+    if showPlots2debug; figure; imagesc(abs(FP2.*windowMASK2)); axis image; colorbar; title('Fine sampled DFT (windowed)'); end
+    OUT = LP1 + LP2;
+    if showPlots2debug; figure; imagesc(abs(OUT)); axis image; colorbar; title('Lyot plane'); end
+
+    if useGPU
+        OUT = gather(OUT);
+    end
+    
+end

--- a/lib/propcustom/propcustom_mft_Pup2Vortex2Pup.m
+++ b/lib/propcustom/propcustom_mft_Pup2Vortex2Pup.m
@@ -25,10 +25,10 @@ function OUT = propcustom_mft_Pup2Vortex2Pup(IN, charge, apRad, inVal, outVal, u
     showPlots2debug = false; 
 
     D = 2*apRad;
-    pixres = 4;%samples per lambda/D
+    pixres = 4; % samples per lambda/D in coarse-resolution DFT
     
     [NA, ~] = size(IN);
-    NB = pixres*D; 
+    NB = ceil_even(pixres*D); 
     
     [X, Y] = meshgrid(-NB/2:NB/2-1);
     RHO = sqrt(X.^2 + Y.^2);

--- a/lib/propcustom/propcustom_mft_Pup2Vortex2Pup.m
+++ b/lib/propcustom/propcustom_mft_Pup2Vortex2Pup.m
@@ -56,7 +56,7 @@ function OUT = propcustom_mft_Pup2Vortex2Pup(IN, charge, apRad, inVal, outVal, u
 
     if showPlots2debug; figure;imagesc(abs(IN));axis image;colorbar; title('pupil'); end
 
-    %% Large scale DFT
+    %% Coarse resolution, full FOV DFT
 
     % Generate central opaque spot
     if diamSpotLamD > 0
@@ -67,19 +67,19 @@ function OUT = propcustom_mft_Pup2Vortex2Pup(IN, charge, apRad, inVal, outVal, u
         inputs.centering = 'pixel';
         inputs.xOffset = offsetsLamD(1);
         inputs.yOffset = offsetsLamD(2);
-        spot1 = falco_gen_annular_FPM(inputs);
-        spot1 = pad_crop(spot1, NB, 'extrapval', 1);
+        spotCoarse = falco_gen_annular_FPM(inputs);
+        spotCoarse = pad_crop(spotCoarse, NB, 'extrapval', 1);
     else
-        spot1 = 1;
+        spotCoarse = 1;
     end
     
     FP1 = 1/(1*D*pixres)*exp(-1i*2*pi*u1'*x)*IN*exp(-1i*2*pi*x'*u1); 
     if showPlots2debug; figure;imagesc(log10(abs(FP1).^2));axis image;colorbar; title('Large scale DFT'); end
 
-    LP1 = 1/(1*D*pixres)*exp(-1i*2*pi*x'*u1)*(FP1.*spot1.*FPM.*(1-windowMASK1))*exp(-1i*2*pi*u1'*x);
+    LP1 = 1/(1*D*pixres)*exp(-1i*2*pi*x'*u1)*(FP1.*spotCoarse.*FPM.*(1-windowMASK1))*exp(-1i*2*pi*u1'*x);
     if showPlots2debug; figure;imagesc(abs(FP1.*(1-windowMASK1)));axis image;colorbar; title('Large scale DFT (windowed)'); end
     
-    %% Fine sampled DFT
+    %% Fine resolution, smaller FOV DFT
 
     % Generate central opaque spot
     if diamSpotLamD > 0
@@ -90,16 +90,16 @@ function OUT = propcustom_mft_Pup2Vortex2Pup(IN, charge, apRad, inVal, outVal, u
         inputs.centering = 'pixel';
         inputs.xOffset = offsetsLamD(1);
         inputs.yOffset = offsetsLamD(2);
-        spot2 = falco_gen_annular_FPM(inputs);
-        spot2 = pad_crop(spot2, NB, 'extrapval', 1);
+        spotFine = falco_gen_annular_FPM(inputs);
+        spotFine = pad_crop(spotFine, NB, 'extrapval', 1);
     else
-        spot2 = 1;
+        spotFine = 1;
     end
     
     FP2 = 2*outVal/(1*D*NB)*exp(-1i*2*pi*u2'*x)*IN*exp(-1i*2*pi*x'*u2); 
     if showPlots2debug; figure;imagesc(log10(abs(FP2).^2));axis image;colorbar; title('Fine sampled DFT'); end
     FPM = falco_gen_vortex_mask(charge, NB);
-    LP2 = 2*outVal/(1*D*NB)*exp(-1i*2*pi*x'*u2)*(FP2.*spot2.*FPM.*windowMASK2)*exp(-1i*2*pi*u2'*x);        
+    LP2 = 2*outVal/(1*D*NB)*exp(-1i*2*pi*x'*u2)*(FP2.*spotFine.*FPM.*windowMASK2)*exp(-1i*2*pi*u2'*x);        
     if showPlots2debug; figure;imagesc(abs(FP2.*windowMASK2));axis image;colorbar; title('Fine sampled DFT (windowed)'); end
     OUT = LP1 + LP2;
     if showPlots2debug; figure;imagesc(abs(OUT));axis image;colorbar; title('Lyot plane'); end

--- a/lib/wfsc/falco_gen_pairwise_probe.m
+++ b/lib/wfsc/falco_gen_pairwise_probe.m
@@ -38,7 +38,7 @@
 
 function probeCmd = falco_gen_pairwise_probe(mp, InormDes, phaseShift, starIndex)
 
-if mp.est.probe.xiOffset(starIndex) == 0 && mp.est.probe.xiOffset(starIndex) == 0
+if mp.est.probe.xiOffset(starIndex) == 0 && mp.est.probe.etaOffset(starIndex) == 0
     error("Probed region's center must be offset from the star location.")
 end
 

--- a/models/model_Jacobian_VC.m
+++ b/models/model_Jacobian_VC.m
@@ -157,26 +157,37 @@ if(whichDM == 1)
             xis = (-(Nxi-1)/2:(Nxi-1)/2)*dxi;
         end
         etas = xis.';
-        
-        vortex = falco_gen_vortex_mask(charge, Nxi);
+                
+        inputs.type = mp.F3.phaseMaskType;
+        inputs.N = Nxi;
+        inputs.charge = charge;
+        inputs.clocking = mp.F3.clocking;
+        inputs.Nsteps = mp.F3.NstepStaircase;
+        fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;
         
     else % Use FFTs
         % Generate central opaque spot
-        if mp.F3.VortexSpotDiam > 0
+        if (mp.F3.VortexSpotDiam > 0) && strcmpi(mp.F3.phaseMaskType, 'vortex')
             inputs.pixresFPM = Nfft1/mp.P1.compact.Nbeam; %--pixels per lambda/D
             inputs.rhoInner = mp.F3.VortexSpotDiam/2*(mp.lambda0/lambda); % radius of inner FPM amplitude spot (in lambda_c/D)
             inputs.rhoOuter = inf; % radius of outer opaque FPM ring (in lambda_c/D)
             inputs.FPMampFac = 0; % amplitude transmission of inner FPM spot
             inputs.centering = 'pixel';
-            spot = falco_gen_annular_FPM(inputs);
+            spot = falco_gen_annular_FPM(inputs); clear inputs;
             spot = pad_crop(spot, Nfft1, 'extrapval', 1);
         else
             spot = 1;
         end
         
+        inputs.type = mp.F3.phaseMaskType;
+        inputs.N = Nfft1;
+        inputs.charge = charge;
+        inputs.clocking = mp.F3.clocking;
+        inputs.Nsteps = mp.F3.NstepStaircase;
+        fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;
+                
         % Generate FPM with fftshift already applied
-        vortex = falco_gen_vortex_mask(charge, Nfft1);
-        fftshiftVortex = fftshift(spot.*vortex);    
+        fftshiftVortex = fftshift(spot.*fpm);    
     end
     
     if any(mp.dm_ind == 2)
@@ -233,7 +244,7 @@ if(whichDM == 1)
 
                 %--MFT from pupil P3 to FPM
                 EF3inc = rect_mat_pre * dEP3box * rect_mat_post; % MFT to FPM
-                EF3 = vortex .* EF3inc; %--Propagate through (1-complex FPM) for Babinet's principle
+                EF3 = fpm .* EF3inc;
                 
                 %--MFT to LS
                 EP4 = propcustom_mft_FtoP(EF3, mp.fl, lambda, dxi, deta, mp.P4.compact.dx, mp.P4.compact.Narr, mp.centering);                
@@ -349,25 +360,37 @@ if(whichDM==2)
             xis = (-(Nxi-1)/2:(Nxi-1)/2)*dxi;
         end
         etas = xis.';
-        
-        vortex = falco_gen_vortex_mask(charge, Nxi);
+                
+        inputs.type = mp.F3.phaseMaskType;
+        inputs.N = Nxi;
+        inputs.charge = charge;
+        inputs.clocking = mp.F3.clocking;
+        inputs.Nsteps = mp.F3.NstepStaircase;
+        fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;
+
     else        
         % Generate central opaque spot
-        if mp.F3.VortexSpotDiam > 0
+        if (mp.F3.VortexSpotDiam > 0) && strcmpi(mp.F3.phaseMaskType, 'vortex')
             inputs.pixresFPM = Nfft2/mp.P1.compact.Nbeam; %--pixels per lambda/D
             inputs.rhoInner = mp.F3.VortexSpotDiam/2*(mp.lambda0/lambda); % radius of inner FPM amplitude spot (in lambda_c/D)
             inputs.rhoOuter = inf; % radius of outer opaque FPM ring (in lambda_c/D)
             inputs.FPMampFac = 0; % amplitude transmission of inner FPM spot
             inputs.centering = 'pixel';
-            spot = falco_gen_annular_FPM(inputs);
+            spot = falco_gen_annular_FPM(inputs); clear inputs;
             spot = pad_crop(spot, Nfft2, 'extrapval', 1);
         else
             spot = 1;
         end
         
+        inputs.type = mp.F3.phaseMaskType;
+        inputs.N = Nfft2;
+        inputs.charge = charge;
+        inputs.clocking = mp.F3.clocking;
+        inputs.Nsteps = mp.F3.NstepStaircase;
+        fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;
+        
         % Generate FPM with fftshift already applied
-        vortex = falco_gen_vortex_mask(charge, Nfft2);
-        fftshiftVortex = fftshift(spot.*vortex);        
+        fftshiftVortex = fftshift(spot.*fpm);        
     end
     
     apodReimaged = padOrCropEven( apodReimaged, mp.dm2.compact.NdmPad);
@@ -415,7 +438,7 @@ if(whichDM==2)
 
                 %--MFT from pupil P3 to FPM
                 EF3inc = rect_mat_pre * dEP3box * rect_mat_post; % MFT to FPM
-                EF3 = vortex.*EF3inc; %--Propagate through (1-complex FPM) for Babinet's principle
+                EF3 = fpm.*EF3inc;
                 
                 %--MFT to LS
                 EP4 = propcustom_mft_FtoP(EF3, mp.fl, lambda, dxi, deta, mp.P4.compact.dx, mp.P4.compact.Narr, mp.centering);  

--- a/models/model_Jacobian_VC.m
+++ b/models/model_Jacobian_VC.m
@@ -74,8 +74,8 @@ else
     apodReimaged = ones(NdmPad); 
 end
 
-if(mp.flagDM1stop); DM1stop = padOrCropEven(mp.dm1.compact.mask, NdmPad); else; DM1stop = ones(NdmPad); end
-if(mp.flagDM2stop); DM2stop = padOrCropEven(mp.dm2.compact.mask, NdmPad); else; DM2stop = ones(NdmPad); end
+if mp.flagDM1stop; DM1stop = padOrCropEven(mp.dm1.compact.mask, NdmPad); else; DM1stop = ones(NdmPad); end
+if mp.flagDM2stop; DM2stop = padOrCropEven(mp.dm2.compact.mask, NdmPad); else; DM2stop = ones(NdmPad); end
 
 if any(mp.dm_ind == 1); DM1surf = padOrCropEven(mp.dm1.compact.surfM, NdmPad); else; DM1surf = 0; end 
 if any(mp.dm_ind == 2); DM2surf = padOrCropEven(mp.dm2.compact.surfM, NdmPad); else; DM2surf = 0; end 
@@ -83,7 +83,7 @@ if any(mp.dm_ind == 2); DM2surf = padOrCropEven(mp.dm2.compact.surfM, NdmPad); e
 if mp.useGPU
     pupil = gpuArray(pupil);
     Ein = gpuArray(Ein);
-    if(any(mp.dm_ind==1))
+    if any(mp.dm_ind == 1)
         DM1surf = gpuArray(DM1surf);
     end
 end
@@ -128,9 +128,9 @@ Edm1 = DM1stop .* exp(mirrorFac*2*pi*1j*DM1surf/lambda) .* Edm1; %--E-field leav
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %--DM1---------------------------------------------------------
-if(whichDM == 1) 
-    if (mp.flagFiber)
-        if(mp.flagLenslet)
+if whichDM == 1
+    if mp.flagFiber
+        if mp.flagLenslet
             Gmode = zeros(mp.Fend.Nlens, mp.dm1.Nele);
         else
             Gmode = zeros(mp.Fend.corr.Npix, mp.dm1.Nele);
@@ -173,7 +173,7 @@ if(whichDM == 1)
         
     else % Use FFTs
         % Generate central opaque spot
-        if (mp.F3.VortexSpotDiam > 0) && strcmpi(mp.F3.phaseMaskType, 'vortex')
+        if mp.F3.VortexSpotDiam > 0
             inputs.pixresFPM = Nfft1/mp.P1.compact.Nbeam; %--pixels per lambda/D
             inputs.rhoInner = mp.F3.VortexSpotDiam/2*(mp.lambda0/lambda); % radius of inner FPM amplitude spot (in lambda_c/D)
             inputs.rhoOuter = inf; % radius of outer opaque FPM ring (in lambda_c/D)
@@ -203,7 +203,7 @@ if(whichDM == 1)
         DM2surf = zeros(mp.dm1.compact.NdmPad);
     end
     
-    if(mp.flagDM2stop)
+    if mp.flagDM2stop
         DM2stop = padOrCropEven(DM2stop, mp.dm1.compact.NdmPad);
     else
         DM2stop = ones(mp.dm1.compact.NdmPad);
@@ -215,7 +215,7 @@ if(whichDM == 1)
     %--Propagate each actuator from DM2 through the optical system
     Gindex = 1; % initialize index counter
     for iact = mp.dm1.act_ele(:).'
-        if(any(any(mp.dm1.compact.inf_datacube(:, :, iact))))  %--Only compute for acutators specified for use or for influence functions that are not zeroed out
+        if any(any(mp.dm1.compact.inf_datacube(:, :, iact)))  %--Only compute for acutators specified for use or for influence functions that are not zeroed out
         
             %--x- and y- coordinates of the padded influence function in the full padded pupil
             x_box_AS_ind = mp.dm1.compact.xy_box_lowerLeft_AS(1, iact):mp.dm1.compact.xy_box_lowerLeft_AS(1, iact)+NboxPad1AS-1; % x-indices in pupil arrays for the box
@@ -258,7 +258,7 @@ if(whichDM == 1)
                 
             else % Use FFTs to go to/from the vortex
                 %--Re-insert the window around the influence function back into the full beam array.
-                if(isa(dEP2boxEff, 'gpuArray'))
+                if isa(dEP2boxEff, 'gpuArray')
                     EP2eff = gpuArray.zeros(mp.dm1.compact.NdmPad);
                 else
                     EP2eff = zeros(mp.dm1.compact.NdmPad);
@@ -286,8 +286,8 @@ if(whichDM == 1)
             EP4 = propcustom_relay(EP4, NrelayFactor*mp.NrelayFend, mp.centering); %--Rotate the final image 180 degrees if necessary
 
             %--MFT to detector
-            if(mp.flagFiber)
-                if(mp.flagLenslet)
+            if mp.flagFiber
+                if mp.flagLenslet
                     for nlens = 1:mp.Fend.Nlens
                         EFend = propcustom_mft_PtoF(EP4, mp.fl, lambda, mp.P4.compact.dx, mp.Fend.dxi, mp.Fend.Nxi, mp.Fend.deta, mp.Fend.Neta, mp.centering, 'xfc', mp.Fend.x_lenslet_phys(nlens), 'yfc', mp.Fend.y_lenslet_phys(nlens));
                         Elenslet = EFend.*mp.Fend.lenslet.mask;
@@ -307,7 +307,7 @@ if(whichDM == 1)
             else    
                 EFend = propcustom_mft_PtoF(EP4, mp.fl, lambda, mp.P4.compact.dx, mp.Fend.dxi, mp.Fend.Nxi, mp.Fend.deta, mp.Fend.Neta, mp.centering);
 
-                if(mp.useGPU)
+                if mp.useGPU
                     EFend = gather(EFend);
                 end
             
@@ -328,9 +328,9 @@ if(whichDM == 1)
 end    
 
 %--DM2---------------------------------------------------------
-if(whichDM==2)
-    if(mp.flagFiber)
-        if(mp.flagLenslet)
+if whichDM == 2
+    if mp.flagFiber
+        if mp.flagLenslet
             Gmode = zeros(mp.Fend.Nlens, mp.dm2.Nele);
         else
             Gmode = zeros(mp.Fend.corr.Npix, mp.dm2.Nele);
@@ -372,7 +372,7 @@ if(whichDM==2)
 
     else        
         % Generate central opaque spot
-        if (mp.F3.VortexSpotDiam > 0) && strcmpi(mp.F3.phaseMaskType, 'vortex')
+        if mp.F3.VortexSpotDiam > 0
             inputs.pixresFPM = Nfft2/mp.P1.compact.Nbeam; %--pixels per lambda/D
             inputs.rhoInner = mp.F3.VortexSpotDiam/2*(mp.lambda0/lambda); % radius of inner FPM amplitude spot (in lambda_c/D)
             inputs.rhoOuter = inf; % radius of outer opaque FPM ring (in lambda_c/D)
@@ -406,8 +406,8 @@ if(whichDM==2)
     
     %--Propagate each actuator from DM2 through the rest of the optical system
     Gindex = 1; % initialize index counter
-    for iact=mp.dm2.act_ele(:).'
-        if(any(any(mp.dm2.compact.inf_datacube(:, :, iact))) ) 
+    for iact = mp.dm2.act_ele(:).'
+        if any(any(mp.dm2.compact.inf_datacube(:, :, iact)))
             
             %--x- and y- coordinates of the padded influence function in the full padded pupil
             x_box_AS_ind = mp.dm2.compact.xy_box_lowerLeft_AS(1, iact):mp.dm2.compact.xy_box_lowerLeft_AS(1, iact)+NboxPad2AS-1; % x-indices in pupil arrays for the box
@@ -415,7 +415,7 @@ if(whichDM==2)
 
             dEbox = mp.dm2.VtoH(iact)*(mirrorFac*2*pi*1j/lambda)*padOrCropEven(mp.dm2.compact.inf_datacube(:, :, iact), NboxPad2AS); %--the padded influence function at DM2
             
-            if(mp.useGPU)
+            if mp.useGPU
                 dEbox = gpuArray(dEbox);
             end
             
@@ -448,7 +448,7 @@ if(whichDM==2)
                 
             else % Use FFTs to go to/from the vortex
             
-                if(isa(dEP2boxEff, 'gpuArray'))
+                if isa(dEP2boxEff, 'gpuArray')
                     EP2eff = gpuArray.zeros(mp.dm2.compact.NdmPad);
                 else
                     EP2eff = zeros(mp.dm2.compact.NdmPad);
@@ -475,8 +475,8 @@ if(whichDM==2)
             EP4 = propcustom_relay(EP4, NrelayFactor*mp.NrelayFend, mp.centering); %--Rotate the final image 180 degrees if necessary
 
             %--MFT to detector
-            if(mp.flagFiber)
-                if(mp.flagLenslet)
+            if mp.flagFiber
+                if mp.flagLenslet
                     for nlens = 1:mp.Fend.Nlens
                         EFend = propcustom_mft_PtoF(EP4, mp.fl, lambda, mp.P4.compact.dx, mp.Fend.dxi, mp.Fend.Nxi, mp.Fend.deta, mp.Fend.Neta, mp.centering, 'xfc', mp.Fend.x_lenslet_phys(nlens), 'yfc', mp.Fend.y_lenslet_phys(nlens));
                         Elenslet = EFend.*mp.Fend.lenslet.mask;

--- a/models/model_compact_general.m
+++ b/models/model_compact_general.m
@@ -131,28 +131,30 @@ if flagUseFPM
     switch upper(mp.coro)
 
         case{'VORTEX', 'VC'}
-            
-            % Get or compute FPM charge.
-            % Single value indicates fully achromatic mask.
-            % Passing an array for mp.F3.VortexCharge with
-            % corresponding wavelengths mp.F3.VortexCharge_lambdas
-            % represents a chromatic vortex FPM
+
+            % Get phase scale factor for the FPM. 
             if numel(mp.F3.VortexCharge) == 1
-                charge = mp.F3.VortexCharge;
+                % Single value indicates fully achromatic mask
+                phaseScaleFac = mp.F3.phaseScaleFac;
             else
-                charge = interp1(mp.F3.VortexCharge_lambdas, mp.F3.VortexCharge, lambda, 'linear', 'extrap');
+                % Passing an array for mp.F3.phaseScaleFac with corresponding
+                % wavelengthsin mp.F3.phaseScaleFacLambdas represents a
+                % chromatic phase FPM.
+                phaseScaleFac = interp1(mp.F3.phaseScaleFacLambdas, mp.F3.phaseScaleFac, lambda, 'linear', 'extrap');
             end
+            
             
             inVal = 0.3;
             outVal = 5;
             switch mp.F3.phaseMaskType
                 case 'vortex'
-                    EP4 = propcustom_mft_Pup2Vortex2Pup(EP3, charge, mp.P1.compact.Nbeam/2, inVal, outVal, ...
+                    EP4 = propcustom_mft_Pup2Vortex2Pup(EP3, mp.F3.VortexCharge, mp.P1.compact.Nbeam/2, inVal, outVal, ...
                         mp.useGPU, mp.F3.VortexSpotDiam*(mp.lambda0/lambda), mp.F3.VortexSpotOffsets*(mp.lambda0/lambda));
                 otherwise
                     inputs.type = mp.F3.phaseMaskType;
                     inputs.N = ceil_even(4*mp.P1.compact.Nbeam);
-                    inputs.charge = charge;
+                    inputs.charge = mp.F3.VortexCharge;
+                    inputs.phaseScaleFac = phaseScaleFac;
                     inputs.clocking = mp.F3.clocking;
                     inputs.Nsteps = mp.F3.NstepStaircase;
                     fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;

--- a/models/model_compact_general.m
+++ b/models/model_compact_general.m
@@ -143,23 +143,20 @@ if flagUseFPM
                 phaseScaleFac = interp1(mp.F3.phaseScaleFacLambdas, mp.F3.phaseScaleFac, lambda, 'linear', 'extrap');
             end
             
-            
             inVal = 0.3;
             outVal = 5;
-            switch mp.F3.phaseMaskType
-                case 'vortex'
-                    EP4 = propcustom_mft_Pup2Vortex2Pup(EP3, mp.F3.VortexCharge, mp.P1.compact.Nbeam/2, inVal, outVal, ...
-                        mp.useGPU, mp.F3.VortexSpotDiam*(mp.lambda0/lambda), mp.F3.VortexSpotOffsets*(mp.lambda0/lambda));
-                otherwise
-                    inputs.type = mp.F3.phaseMaskType;
-                    inputs.N = ceil_even(4*mp.P1.compact.Nbeam);
-                    inputs.charge = mp.F3.VortexCharge;
-                    inputs.phaseScaleFac = phaseScaleFac;
-                    inputs.clocking = mp.F3.clocking;
-                    inputs.Nsteps = mp.F3.NstepStaircase;
-                    fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;
-                    EP4 = propcustom_mft_PtoFtoP(EP3, fpm, mp.P1.compact.Nbeam/2, inVal, outVal, mp.useGPU);
-            end
+            spotDiam = mp.F3.VortexSpotDiam * (mp.lambda0/lambda);
+            spotOffsets = mp.F3.VortexSpotOffsets * (mp.lambda0/lambda);
+            pixPerLamD = 4;
+            
+            inputs.type = mp.F3.phaseMaskType;
+            inputs.N = ceil_even(pixPerLamD*mp.P1.compact.Nbeam);
+            inputs.charge = mp.F3.VortexCharge;
+            inputs.phaseScaleFac = phaseScaleFac;
+            inputs.clocking = mp.F3.clocking;
+            inputs.Nsteps = mp.F3.NstepStaircase;
+            fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;
+            EP4 = propcustom_mft_PtoFtoP(EP3, fpm, mp.P1.compact.Nbeam/2, inVal, outVal, mp.useGPU, spotDiam, spotOffsets);
             
             % Undo the rotation inherent to propcustom_mft_Pup2Vortex2Pup.m
             if ~mp.flagRotation; EP4 = propcustom_relay(EP4, -1, mp.centering); end

--- a/models/model_compact_general.m
+++ b/models/model_compact_general.m
@@ -131,6 +131,7 @@ if flagUseFPM
     switch upper(mp.coro)
 
         case{'VORTEX', 'VC'}
+            
             % Get or compute FPM charge.
             % Single value indicates fully achromatic mask.
             % Passing an array for mp.F3.VortexCharge with
@@ -141,16 +142,29 @@ if flagUseFPM
             else
                 charge = interp1(mp.F3.VortexCharge_lambdas, mp.F3.VortexCharge, lambda, 'linear', 'extrap');
             end
-            EP4 = propcustom_mft_Pup2Vortex2Pup( EP3, charge, mp.P1.compact.Nbeam/2, 0.3, 5, ...
-                mp.useGPU, mp.F3.VortexSpotDiam*(mp.lambda0/lambda), mp.F3.VortexSpotOffsets*(mp.lambda0/lambda));
+            
+            inVal = 0.3;
+            outVal = 5;
+            switch mp.F3.phaseMaskType
+                case 'vortex'
+                    EP4 = propcustom_mft_Pup2Vortex2Pup(EP3, charge, mp.P1.compact.Nbeam/2, inVal, outVal, ...
+                        mp.useGPU, mp.F3.VortexSpotDiam*(mp.lambda0/lambda), mp.F3.VortexSpotOffsets*(mp.lambda0/lambda));
+                otherwise
+                    inputs.type = mp.F3.phaseMaskType;
+                    inputs.N = ceil_even(4*mp.P1.compact.Nbeam);
+                    inputs.charge = charge;
+                    inputs.clocking = mp.F3.clocking;
+                    inputs.Nsteps = mp.F3.NstepStaircase;
+                    fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;
+                    EP4 = propcustom_mft_PtoFtoP(EP3, fpm, mp.P1.compact.Nbeam/2, inVal, outVal, mp.useGPU);
+            end
+            
             % Undo the rotation inherent to propcustom_mft_Pup2Vortex2Pup.m
             if ~mp.flagRotation; EP4 = propcustom_relay(EP4, -1, mp.centering); end
 
             % Resize beam if Lyot plane has different resolution
             if mp.P4.compact.Nbeam ~= mp.P1.compact.Nbeam
                 N1 = length(EP4);
-%                 mag = mp.P4.compact.Nbeam / mp.P1.compact.Nbeam;
-%                 N4 = ceil_even(mag*N1);
                 N4 = ceil_even(1.1*mp.P4.compact.Narr);
                 if strcmpi(mp.centering, 'pixel')
                     x1 = (-N1/2:(N1/2-1))/mp.P1.compact.Nbeam;
@@ -240,12 +254,10 @@ else % No FPM in beam path, so relay directly from P3 to P4.
     
     EP4 = propcustom_relay(EP3, NrelayFactor*mp.Nrelay3to4, mp.centering);
     EP4 = transOuterFPM * EP4;
-%     figure(551); imagesc(abs(EP4)); axis xy equal tight; colorbar; drawnow;
+
     % Interpolate beam if Lyot plane has different resolution
     if mp.P4.compact.Nbeam ~= mp.P1.compact.Nbeam
         N1 = length(EP4);
-%         mag = mp.P4.compact.Nbeam / mp.P1.compact.Nbeam;
-%         N4 = ceil_even(mag*N1);
         N4 = ceil_even(1.1*mp.P4.compact.Narr);
         if strcmpi(mp.centering, 'pixel')
             x1 = (-N1/2:(N1/2-1)) / mp.P1.compact.Nbeam;

--- a/models/model_full_Fourier.m
+++ b/models/model_full_Fourier.m
@@ -134,21 +134,18 @@ switch upper(mp.coro)
         
         inVal = 0.3;
         outVal = 5;
-        switch mp.F3.phaseMaskType
-            case 'vortex'
-                EP4 = propcustom_mft_Pup2Vortex2Pup(EP3, mp.F3.VortexCharge, mp.P1.full.Nbeam/2, inVal, outVal, ...
-                    mp.useGPU, mp.F3.VortexSpotDiam*(mp.lambda0/lambda), mp.F3.VortexSpotOffsets*(mp.lambda0/lambda));
-
-            otherwise
-                inputs.type = mp.F3.phaseMaskType;
-                inputs.N = ceil_even(4*mp.P1.full.Nbeam);
-                inputs.charge = mp.F3.VortexCharge;
-                inputs.phaseScaleFac = phaseScaleFac;
-                inputs.clocking = mp.F3.clocking;
-                inputs.Nsteps = mp.F3.NstepStaircase;
-                fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;
-                EP4 = propcustom_mft_PtoFtoP(EP3, fpm, mp.P1.full.Nbeam/2, inVal, outVal, mp.useGPU);
-        end
+        spotDiam = mp.F3.VortexSpotDiam * (mp.lambda0/lambda);
+        spotOffsets = mp.F3.VortexSpotOffsets * (mp.lambda0/lambda);
+        pixPerLamD = 4;
+        
+        inputs.type = mp.F3.phaseMaskType;
+        inputs.N = ceil_even(pixPerLamD*mp.P1.full.Nbeam);
+        inputs.charge = mp.F3.VortexCharge;
+        inputs.phaseScaleFac = phaseScaleFac;
+        inputs.clocking = mp.F3.clocking;
+        inputs.Nsteps = mp.F3.NstepStaircase;
+        fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;
+        EP4 = propcustom_mft_PtoFtoP(EP3, fpm, mp.P1.full.Nbeam/2, inVal, outVal, mp.useGPU, spotDiam, spotOffsets);
         
         % Undo the rotation inherent to propcustom_mft_Pup2Vortex2Pup.m
         if ~mp.flagRotation; EP4 = propcustom_relay(EP4, -1, mp.centering); end

--- a/models/model_full_Fourier.m
+++ b/models/model_full_Fourier.m
@@ -120,29 +120,30 @@ switch upper(mp.coro)
         if mp.flagApod == false
             EP3 = pad_crop(EP3, 2^nextpow2(mp.P1.full.Narr)); %--Crop down if there isn't an apodizer mask
         end
-        % Get FPM charge 
-        if(numel(mp.F3.VortexCharge)==1)
-            % single value indicates fully achromatic mask
-            charge = mp.F3.VortexCharge;
+
+        % Get phase scale factor for FPM. 
+        if numel(mp.F3.VortexCharge) == 1
+            % Single value indicates fully achromatic mask
+            phaseScaleFac = mp.F3.phaseScaleFac;
         else
-            % Passing an array for mp.F3.VortexCharge with
-            % corresponding wavelengths mp.F3.VortexCharge_lambdas
-            % represents a chromatic vortex FPM
-            charge = interp1(mp.F3.VortexCharge_lambdas, mp.F3.VortexCharge, lambda, 'linear', 'extrap');
+            % Passing an array for mp.F3.phaseScaleFac with corresponding
+            % wavelengthsin mp.F3.phaseScaleFacLambdas represents a
+            % chromatic phase FPM.
+            phaseScaleFac = interp1(mp.F3.phaseScaleFacLambdas, mp.F3.phaseScaleFac, lambda, 'linear', 'extrap');
         end
-        
         
         inVal = 0.3;
         outVal = 5;
         switch mp.F3.phaseMaskType
             case 'vortex'
-                EP4 = propcustom_mft_Pup2Vortex2Pup(EP3, charge, mp.P1.full.Nbeam/2, inVal, outVal, ...
+                EP4 = propcustom_mft_Pup2Vortex2Pup(EP3, mp.F3.VortexCharge, mp.P1.full.Nbeam/2, inVal, outVal, ...
                     mp.useGPU, mp.F3.VortexSpotDiam*(mp.lambda0/lambda), mp.F3.VortexSpotOffsets*(mp.lambda0/lambda));
 
             otherwise
                 inputs.type = mp.F3.phaseMaskType;
                 inputs.N = ceil_even(4*mp.P1.full.Nbeam);
-                inputs.charge = charge;
+                inputs.charge = mp.F3.VortexCharge;
+                inputs.phaseScaleFac = phaseScaleFac;
                 inputs.clocking = mp.F3.clocking;
                 inputs.Nsteps = mp.F3.NstepStaircase;
                 fpm = falco_gen_azimuthal_phase_mask(inputs); clear inputs;

--- a/setup/falco_set_optional_variables.m
+++ b/setup/falco_set_optional_variables.m
@@ -95,10 +95,13 @@ if(isfield(mp.full,'pol_conds')==false);  mp.full.pol_conds = 0;  end %--Vector 
 %--Propagation method
 if(isfield(mp,'propMethodPTP')==false);  mp.propMethodPTP = 'fft';  end %--Propagation method for postage stamps around the influence functions. 'mft' or 'fft'
 
-%--Vortex coronagraphs
+%--Vortex or other azithumal, phase-only FPMs
 if(isfield(mp.jac, 'mftToVortex')==false);  mp.jac.mftToVortex = false;  end  %--Whether to use MFTs to propagate to/from the vortex FPM
 if(isfield(mp.F3, 'VortexSpotDiam')==false);  mp.F3.VortexSpotDiam = 0;  end  %--Diameter of the opaque spot at the center of the vortex. [lambda0/D]
 if(isfield(mp.F3, 'VortexSpotOffsets')==false);  mp.F3.VortexSpotOffsets = [0 0];  end  %--Offsets for the opaque spot at the center of the vortex. [lambda0/D]
+if(isfield(mp.F3, 'phaseMaskType')==false);  mp.F3.phaseMaskType = 'vortex';  end  % Type of phase FPMs allowed: 'vortex', 'cos', 'sectors', and 'staircase'.
+if(isfield(mp.F3, 'NstepStaircase')==false);  mp.F3.NstepStaircase = 6;  end  % Number of discrete steps per 2*pi radians of phase for a staircase phase mask at F3.
+if(isfield(mp.F3, 'clocking')==false);  mp.F3.clocking = 0;  end  % Counterclockwise clocking of the phase FPM [degrees].
 
 %--Sensitivities to Zernike-Mode Perturbations
 if(isfield(mp.full,'ZrmsVal')==false);  mp.full.ZrmsVal = 1e-9;  end %--Amount of RMS Zernike mode used to calculate aberration sensitivities [meters]. WFIRST CGI uses 1e-9, and LUVOIR and HabEx use 1e-10. 

--- a/setup/falco_set_optional_variables.m
+++ b/setup/falco_set_optional_variables.m
@@ -102,6 +102,7 @@ if(isfield(mp.F3, 'VortexSpotOffsets')==false);  mp.F3.VortexSpotOffsets = [0 0]
 if(isfield(mp.F3, 'phaseMaskType')==false);  mp.F3.phaseMaskType = 'vortex';  end  % Type of phase FPMs allowed: 'vortex', 'cos', 'sectors', and 'staircase'.
 if(isfield(mp.F3, 'NstepStaircase')==false);  mp.F3.NstepStaircase = 6;  end  % Number of discrete steps per 2*pi radians of phase for a staircase phase mask at F3.
 if(isfield(mp.F3, 'clocking')==false);  mp.F3.clocking = 0;  end  % Counterclockwise clocking of the phase FPM [degrees].
+if(isfield(mp.F3, 'phaseScaleFac')==false);  mp.F3.phaseScaleFac = 1;  end  % Factor to apply to the phase in the phase FPM. Use a vector to add chromaticity to the model. 
 
 %--Sensitivities to Zernike-Mode Perturbations
 if(isfield(mp.full,'ZrmsVal')==false);  mp.full.ZrmsVal = 1e-9;  end %--Amount of RMS Zernike mode used to calculate aberration sensitivities [meters]. WFIRST CGI uses 1e-9, and LUVOIR and HabEx use 1e-10. 


### PR DESCRIPTION
Under the 'vortex' type for `mp.coro`, the optional variable mp.F3.phaseMaskType can be used to choose among 'vortex', 'cos', 'sectors', and 'staircase'. The charge is applied in the same way for each. The staircase option also requires the number of steps, given by the new variable `mp.F3.NstepStaircase`.