### PR TITLE
Added ProbeSchedule class

### DIFF
--- a/config/EXAMPLE_defaults_DST_FLC_design.m
+++ b/config/EXAMPLE_defaults_DST_FLC_design.m
@@ -40,16 +40,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
-mp.estimator = 'pwp-bp-square';
+mp.estimator = 'pairwise';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_DST_LC_design.m
+++ b/config/EXAMPLE_defaults_DST_LC_design.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
-mp.estimator = 'pwp-bp-square';
+mp.estimator = 'pairwise';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_LUVOIRA_APLC_largeFPM.m
+++ b/config/EXAMPLE_defaults_LUVOIRA_APLC_largeFPM.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;%2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;%20;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_LUVOIRA_APLC_mediumFPM.m
+++ b/config/EXAMPLE_defaults_LUVOIRA_APLC_mediumFPM.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;%2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;%20;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_LUVOIRA_APLC_smallFPM.m
+++ b/config/EXAMPLE_defaults_LUVOIRA_APLC_smallFPM.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;%2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;%20;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_LUVOIRB_VC_design.m
+++ b/config/EXAMPLE_defaults_LUVOIRB_VC_design.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_LUVOIRB_VC_design_fibers.m
+++ b/config/EXAMPLE_defaults_LUVOIRB_VC_design_fibers.m
@@ -38,16 +38,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 8;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_MSWC.m
+++ b/config/EXAMPLE_defaults_MSWC.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 3;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
-mp.estimator = 'pwp-bp';
+mp.estimator = 'pairwise-rect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.width = [4, 4]; % Width of probed rectangular region. Units of lambda/D.

--- a/config/EXAMPLE_defaults_VC_simple.m
+++ b/config/EXAMPLE_defaults_VC_simple.m
@@ -36,17 +36,17 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
-mp.estimator = 'pwp-bp-square';
+mp.estimator = 'pairwise';
 
 %--Variables for pairwise probing estimation:
-mp.est.flagUseJac = true;    % Whether to use the Jacobian to compute the delta electric fields. If false, the outputs of model_compact are differenced instead.
+mp.est.probe = Probe; % initialize object
+% mp.est.flagUseJac = true;    % Whether to use the Jacobian to compute the delta electric fields. If false, the outputs of model_compact are differenced instead.
 mp.est.probe.Npairs = 3;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_WFIRST_FOHLC.m
+++ b/config/EXAMPLE_defaults_WFIRST_FOHLC.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;%2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;%20;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_WFIRST_HLC_BMC_WFE.m
+++ b/config/EXAMPLE_defaults_WFIRST_HLC_BMC_WFE.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;%2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;%20;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_WFIRST_LC.m
+++ b/config/EXAMPLE_defaults_WFIRST_LC.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;%2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;%20;    % Max x/y extent of probed region [lambda/D].

--- a/config/EXAMPLE_defaults_WFIRST_PhaseB_SPC_Spec_simple.m
+++ b/config/EXAMPLE_defaults_WFIRST_PhaseB_SPC_Spec_simple.m
@@ -36,19 +36,19 @@ mp.Nwpsbp = 3;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
-mp.est.probe.Npairs = 3;%2;     % Number of pair-wise probe PAIRS to use.
+mp.est.probe = Probe; % initialize object
+mp.est.probe.Npairs = 3;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
-mp.est.probe.radius = 12;%20;    % Max x/y extent of probed region [lambda/D].
+mp.est.probe.radius = 12;    % Max x/y extent of probed region [lambda/D].
 mp.est.probe.xOffset = 0;   % offset of probe center in x [actuators]. Use to avoid central obscurations.
 mp.est.probe.yOffset = 14;    % offset of probe center in y [actuators]. Use to avoid central obscurations.
 mp.est.probe.axis = 'alternate';     % which axis to have the phase discontinuity along [x or y or xy/alt/alternate]

--- a/config/EXAMPLE_defaults_try_running_FALCO.m
+++ b/config/EXAMPLE_defaults_try_running_FALCO.m
@@ -36,16 +36,16 @@ mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;    % Max x/y extent of probed region [lambda/D].
@@ -62,7 +62,7 @@ mp.logGmin = -6;  % 10^(mp.logGmin) used on the intensity of DM1 and DM2 Jacobia
 %--Zernikes to suppress with controller
 mp.jac.zerns = 1;  %--Which Zernike modes to include in Jacobian. Given as the max Noll index. Always include the value "1" for the on-axis piston mode.
 mp.jac.Zcoef = 1e-9*ones(size(mp.jac.zerns)); %--meters RMS of Zernike aberrations. (piston value is reset to 1 later)
-    
+
 %--Zernikes to compute sensitivities for
 mp.eval.indsZnoll = 2:3; %--Noll indices of Zernikes to compute values for
 %--Annuli to compute 1nm RMS Zernike sensitivities over. Columns are [inner radius, outer radius]. One row per annulus.

--- a/lib/@Probe/Probe.m
+++ b/lib/@Probe/Probe.m
@@ -9,19 +9,19 @@
 classdef Probe
     
     properties
-        Npairs = 3; % Number of pair-wise probe pairs to use.
-        whichDM = 1; % Which DM to use for probing. 1 or 2.
-        xOffset = 0; % Offset of probe center at DM in x [actuators]. Use to avoid obscurations.
-        yOffset = 0; % Offset of probe center at DM in y [actuators]. Use to avoid obscurations.
+        Npairs (1, 1) double {mustBePositive} = 3; % Number of pair-wise probe pairs to use.
+        whichDM (1, 1) int16 {mustBePositive} = 1; % Which DM to use for probing. 1 or 2.
+        xOffset (1, 1) int16 = 0; % x-offset of the probe center from the DM grid center [actuators]. Use to avoid obscurations.
+        yOffset (1, 1) int16 = 0; % y-offset of the probe center from the DM grid center [actuators]. Use to avoid obscurations.
         gainFudge = 1; % empirical fudge factor to make average probe amplitude match desired value.
 
-        radius = 12; % Half-width of the square probed region in the image plane [lambda/D]. (NOTE: Only used for square probes.)
-        axis = 'alternate'; % Which axis to have the phase discontinuity along. Values can be 'x', 'y', or 'xy' / 'alt' / 'alternate'. The 'alternate' option causes the bad axis to switch between x and y for each subsequent probe pair.  (NOTE: Only used for square probes.)
+        radius (1, 1) double {mustBePositive} = 12; % Half-width of the square probed region in the image plane [lambda/D]. (NOTE: Only used for square probes.)
+        axis string = 'alternate'; % Which axis to have the phase discontinuity along. Values can be 'x', 'y', or 'xy' / 'alt' / 'alternate'. The 'alternate' option causes the bad axis to switch between x and y for each subsequent probe pair.  (NOTE: Only used for square probes.)
         
-        width = 12; % Width of rectangular probe in focal plane [lambda/D]. (NOTE: Only used for rectangular probes. radius is used instead for a square probed region)
-        xiOffset = 6; % Horizontal offset from star of rectangular probe in focal plane [lambda/D].  (NOTE: Only used for rectangular probes. No offset for square probed region.)
-        height = 24; % Height of rectangular probe in focal plane [lambda/D].  (NOTE: Only used for rectangular probes. radius is used instead for a square probed region)
-        etaOffset = 0; % Vertical offset from star of rectangular probe in focal plane [lambda/D].  (NOTE: Only used for rectangular probes. No offset for square probed region.)
+        width double {mustBePositive} = 12; % Width of rectangular probe in focal plane [lambda/D]. (NOTE: Only used for rectangular probes. radius is used instead for a square probed region)
+        xiOffset double = 6; % Horizontal offset from star of rectangular probe in focal plane [lambda/D].  (NOTE: Only used for rectangular probes. No offset for square probed region.)
+        height double {mustBePositive} = 24; % Height of rectangular probe in focal plane [lambda/D].  (NOTE: Only used for rectangular probes. radius is used instead for a square probed region)
+        etaOffset double = 0; % Vertical offset from star of rectangular probe in focal plane [lambda/D].  (NOTE: Only used for rectangular probes. No offset for square probed region.)
 
    end
    

--- a/lib/@ProbeSchedule/ProbeSchedule.m
+++ b/lib/@ProbeSchedule/ProbeSchedule.m
@@ -1,0 +1,17 @@
+% Copyright 2018-2021, by the California Institute of Technology. ALL RIGHTS
+% RESERVED. United States Government Sponsorship acknowledged. Any
+% commercial use must be negotiated with the Office of Technology Transfer
+% at the California Institute of Technology.
+% -------------------------------------------------------------------------
+%
+% Object containing the vectors of probing values scheduled at each WFSC iteration.
+
+classdef ProbeSchedule
+    
+    properties
+        xOffsetVec int8 % Vector of x-offsets (one value per WFSC iteration) of the probe center from the DM grid center [actuators]
+        yOffsetVec int8 % Vector of x-offsets (one value per WFSC iteration) of the probe center from the DM grid center [actuators]
+        InormProbeVec double {mustBePositive} %= 1e-6*ones(10, 1) % Vector of the desired normalized intensity of the probes at each WFSC iteration 
+   end
+   
+end

--- a/lib/wfsc/falco_est.m
+++ b/lib/wfsc/falco_est.m
@@ -25,7 +25,7 @@ function ev = falco_est(mp, ev, jacStruct)
             ev  = falco_est_perfect_Efield_with_Zernikes(mp);
             ev.Im = falco_get_summed_image(mp);
             
-        case{'pwp-bp-square', 'pwp-bp', 'pwp-kf'}
+        case{'pwp-bp-square', 'pwp-bp', 'pwp-kf', 'pairwise', 'pairwise-square', 'pairwise-rect'}
             if(mp.flagFiber && mp.flagLenslet)
 				if mp.est.flagUseJac
 					ev = falco_est_pairwise_probing_fiber(mp, jacStruct);

--- a/lib/wfsc/falco_gen_pairwise_probe.m
+++ b/lib/wfsc/falco_gen_pairwise_probe.m
@@ -52,8 +52,8 @@ Nact = dm.Nact;
 NactPerBeam = mp.P2.D / dm.dm_spacing;
 
 % Coordinates in actuator space
-xs = (-(Nact-1)/2:(Nact-1)/2)/Nact - round(mp.est.probe.xOffset)/Nact;
-ys = (-(Nact-1)/2:(Nact-1)/2)/Nact - round(mp.est.probe.yOffset)/Nact;
+xs = (-(Nact-1)/2:(Nact-1)/2)/Nact - double(round(mp.est.probe.xOffset))/Nact;
+ys = (-(Nact-1)/2:(Nact-1)/2)/Nact - double(round(mp.est.probe.yOffset))/Nact;
 [XS, YS] = meshgrid(xs, ys);
 
 % Convert units from lambda/D to actuators

--- a/lib/wfsc/falco_gen_pairwise_probe_square.m
+++ b/lib/wfsc/falco_gen_pairwise_probe_square.m
@@ -39,9 +39,9 @@ Nact = dm.Nact;
 NactPerBeam = mp.P2.D / dm.dm_spacing;
 
 %--Coordinates in actuator space
-xs = (-(Nact-1)/2:(Nact-1)/2)/Nact - round(mp.est.probe.xOffset)/Nact;
-ys = (-(Nact-1)/2:(Nact-1)/2)/Nact - round(mp.est.probe.yOffset)/Nact;
-[XS,YS] = meshgrid(xs,ys);
+xs = (-(Nact-1)/2:(Nact-1)/2)/Nact - double(round(mp.est.probe.xOffset))/Nact;
+ys = (-(Nact-1)/2:(Nact-1)/2)/Nact - double(round(mp.est.probe.yOffset))/Nact;
+[XS, YS] = meshgrid(xs, ys);
 
 % Probed region extend in dark hole
 lamDIntoAct = Nact / NactPerBeam; % Convert units from lambda/D to actuators

--- a/setup/falco_set_optional_variables.m
+++ b/setup/falco_set_optional_variables.m
@@ -19,7 +19,6 @@ function mp = falco_set_optional_variables(mp)
 %% Intializations of structures (if they don't exist yet)
 mp.jac.dummy = 1;
 mp.est.dummy = 1;
-mp.est.probe.dummy = 1;
 mp.star.dummy = 1;
 mp.compact.star.dummy = 1;
 mp.jac.star.dummy = 1;
@@ -157,9 +156,9 @@ if(isfield(mp,'WspatialDef')==false);  mp.WspatialDef = [];  end %--spatial weig
 if(isfield(mp.jac,'minimizeNI')==false); mp.jac.minimizeNI = false; end %--Have EFC minimize normalized intensity instead of intensity
     
 %--Estimation
-if(isfield(mp.est.probe,'whichDM')==false); mp.est.probe.whichDM = 1; end %--Which DM to use for probing
-if(isfield(mp.est,'InormProbeMax')==false); mp.est.InormProbeMax = 1e-4; end %--Max probe intensity
-if(isfield(mp.est,'Ithreshold')==false); mp.est.Ithreshold = 1e-2; end %--Lower estimated intensities to this value if they exceed this (probably due to a bad inversion)
+if ~isfield(mp.est, 'probeSchedule'); mp.est.probeSchedule = ProbeSchedule; end %--Schedule of per-iteration values for pairwise probing. Default is empty vectors, meaning they aren't used.
+if(isfield(mp.est,'InormProbeMax')==false); mp.est.InormProbeMax = 1e-4; end %--Max allowed probe intensity
+if(isfield(mp.est,'Ithreshold')==false); mp.est.Ithreshold = 1e-2; end %--Reduce estimated intensities to this value if they exceed this (probably due to a bad inversion)
 
 %--Performance Evaluation
 if(isfield(mp.Fend.eval,'res')==false);  mp.Fend.eval.res = 10;  end % pixels per lambda0/D in compact evaluation model's final focus
@@ -177,13 +176,14 @@ if(isfield(mp.P1,'IDnorm')==false); mp.P1.IDnorm = 0; end % Needed for computing
 
 % Default values are for the Andor Neo sCMOS detector and testbed flux
 if ~isfield(mp, 'flagImageNoise'); mp.flagImageNoise = false; end % whether to include noise in the images
-if ~isfield(mp.detector, 'gain'); mp.detector.gain = 1.0; end % [e-/count]
+if ~isfield(mp.detector, 'gain'); mp.detector.gain = 1.0; end % detector gain [e-/count]
 if ~isfield(mp.detector, 'darkCurrentRate'); mp.detector.darkCurrentRate = 0.015; end % [e-/pixel/second]
-if ~isfield(mp.detector, 'readNoiseStd'); mp.detector.readNoiseStd = 1.7; end % [e-/count]
-if ~isfield(mp.detector, 'wellDepth'); mp.detector.wellDepth = 3e4; end % [e-]
+if ~isfield(mp.detector, 'readNoiseStd'); mp.detector.readNoiseStd = 1.7; end % standard deviation of Gaussian read noise [e-]
+if ~isfield(mp.detector, 'wellDepth'); mp.detector.wellDepth = 3e4; end % well depth of the detector [e-]
 if ~isfield(mp.detector, 'peakFluxVec'); mp.detector.peakFluxVec = 1e8 * ones(mp.Nsbp, 1); end % [counts/pixel/second]
-if ~isfield(mp.detector, 'tExpVec'); mp.detector.tExpVec = 1.0 * ones(mp.Nsbp, 1); end % [seconds]
-if ~isfield(mp.detector, 'Nexp'); mp.detector.Nexp = 1; end % number of exposures to stack
+if ~isfield(mp.detector, 'tExpVec'); mp.detector.tExpVec = 1.0 * ones(mp.Nsbp, 1); end % exposure times for regular (unprobed images) in each subband [seconds]
+if ~isfield(mp.detector, 'tExpProbedVec'); mp.detector.tExpUnprobedVec = 1.0 * ones(mp.Nsbp, 1); end % exposure times for probed images in each subband [seconds]
+if ~isfield(mp.detector, 'Nexp'); mp.detector.Nexp = 1; end % number of exposures to stack for each combined frame
 
 %% Initialize some basic attributes for all DMs (which include hybrid FPMs).
 mp.dm1.NactTotal=0; mp.dm2.NactTotal=0; mp.dm3.NactTotal=0; mp.dm4.NactTotal=0; mp.dm5.NactTotal=0; mp.dm6.NactTotal=0; mp.dm7.NactTotal=0; mp.dm8.NactTotal=0; mp.dm9.NactTotal=0; 

--- a/setup/falco_verify_key_values.m
+++ b/setup/falco_verify_key_values.m
@@ -19,7 +19,7 @@ function mp = falco_verify_key_values(mp)
     mp.allowedCenterings = {'pixel', 'interpixel'};
     mp.allowedCoronagraphTypes = {'VC', 'VORTEX', 'LC', 'APLC', 'FLC', 'SPLC', 'HLC'};
     mp.allowedLayouts = {'fourier', 'fpm_scale', 'proper', 'roman_phasec_proper', 'wfirst_phaseb_proper'};
-    mp.allowedEstimators = {'perfect', 'pairwise-square', 'pwp-bp-square', 'pairwise-rect', 'pwp-bp', 'pwp-kf'};
+    mp.allowedEstimators = {'perfect', 'pairwise', 'pairwise-square', 'pwp-bp-square', 'pairwise-rect', 'pwp-bp', 'pwp-kf'};
 
     %--Check centering
     mp.centering = lower(mp.centering);

--- a/testing/tests_long/@ConfigurationFLC/ConfigurationFLC.m
+++ b/testing/tests_long/@ConfigurationFLC/ConfigurationFLC.m
@@ -57,16 +57,16 @@ mp.Nwpsbp = 3;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
-mp.estimator = 'pwp-bp-square';
+mp.estimator = 'pairwise';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;    % Max x/y extent of probed region [lambda/D].

--- a/testing/tests_long/@ConfigurationLC/ConfigurationLC.m
+++ b/testing/tests_long/@ConfigurationLC/ConfigurationLC.m
@@ -54,17 +54,17 @@ mp.Nsbp = 1;            %--Number of sub-bandpasses to divide the whole bandpass
 mp.Nwpsbp = 1;          %--Number of wavelengths to used to approximate an image in each sub-bandpass
 
 %% Wavefront Estimation
-%
-%--Estimator Options:
+
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
-%% New variables for pairwise probing estimation:
+% Variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;%2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;%20;    % Max x/y extent of probed region [lambda/D].

--- a/testing/tests_long/@ConfigurationMSWC/ConfigurationMSWC.m
+++ b/testing/tests_long/@ConfigurationMSWC/ConfigurationMSWC.m
@@ -52,16 +52,16 @@ mp.Nwpsbp = 3;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
-mp.estimator = 'pwp-bp';
+mp.estimator = 'pairwise-rect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 2;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.width = [4, 4]; % Width of probed rectangular region. Units of lambda/D.

--- a/testing/tests_long/@ConfigurationVortex/ConfigurationVortex.m
+++ b/testing/tests_long/@ConfigurationVortex/ConfigurationVortex.m
@@ -52,16 +52,16 @@ mp.Nwpsbp = 3;          %--Number of wavelengths to used to approximate an image
 
 %% Wavefront Estimation
 
-%--Estimator Options:
+% mp.estimator options:
 % - 'perfect' for exact numerical answer from full model
-% - 'pwp-bp' for pairwise probing in the specified rectangular regions for
+% - 'pairwise' or 'pairwise-square' for pairwise probing in a square region
+% centered on the star
+% - 'pairwise-rect' for pairwise probing in the specified rectangular regions for
 %    one or more stars
-% - 'pwp-bp-square' for pairwise probing with batch process estimation in a
-% square region for one star [original functionality of 'pwp-bp' prior to January 2021]
-% - 'pwp-kf' for pairwise probing with Kalman filter [NOT TESTED YET]
 mp.estimator = 'perfect';
 
 %--New variables for pairwise probing estimation:
+mp.est.probe = Probe; % initialize object
 mp.est.probe.Npairs = 3;     % Number of pair-wise probe PAIRS to use.
 mp.est.probe.whichDM = 1;    % Which DM # to use for probing. 1 or 2. Default is 1
 mp.est.probe.radius = 12;    % Max x/y extent of probed region [lambda/D].

--- a/testing/tests_long/TestFunctionalFLC.m
+++ b/testing/tests_long/TestFunctionalFLC.m
@@ -19,12 +19,14 @@ classdef TestFunctionalFLC < matlab.unittest.TestCase
 %
     methods (TestClassSetup)
         function addPath(testCase)
+            addpath(genpath([testCase.mp.path.falco filesep 'models']));
             addpath(genpath([testCase.mp.path.falco filesep 'setup']));
             addpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
     end
     methods (TestClassTeardown)
         function removePath(testCase)
+            rmpath(genpath([testCase.mp.path.falco filesep 'models']))
             rmpath(genpath([testCase.mp.path.falco filesep 'setup']))
             rmpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end

--- a/testing/tests_long/TestFunctionalLC.m
+++ b/testing/tests_long/TestFunctionalLC.m
@@ -19,16 +19,18 @@ classdef TestFunctionalLC < matlab.unittest.TestCase
 %
     methods (TestClassSetup)
         function addPath(testCase)
+            addpath(genpath([testCase.mp.path.falco filesep 'models']));
             addpath(genpath([testCase.mp.path.falco filesep 'setup']));
             addpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
     end
     methods (TestClassTeardown)
         function removePath(testCase)
+            rmpath(genpath([testCase.mp.path.falco filesep 'models']))
             rmpath(genpath([testCase.mp.path.falco filesep 'setup']))
             rmpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
-    end    
+    end
     
 %% *Tests*
 %

--- a/testing/tests_long/TestFunctionalMSWC.m
+++ b/testing/tests_long/TestFunctionalMSWC.m
@@ -19,14 +19,18 @@ classdef TestFunctionalMSWC < matlab.unittest.TestCase
 %
     methods (TestClassSetup)
         function addPath(testCase)
+            addpath(genpath([testCase.mp.path.falco filesep 'models']));
             addpath(genpath([testCase.mp.path.falco filesep 'setup']));
+            addpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
     end
     methods (TestClassTeardown)
         function removePath(testCase)
+            rmpath(genpath([testCase.mp.path.falco filesep 'models']))
             rmpath(genpath([testCase.mp.path.falco filesep 'setup']))
+            rmpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
-    end    
+    end
     
 %% *Tests*
 %

--- a/testing/tests_long/TestFunctionalVortex.m
+++ b/testing/tests_long/TestFunctionalVortex.m
@@ -19,14 +19,18 @@ classdef TestFunctionalVortex < matlab.unittest.TestCase
 %
     methods (TestClassSetup)
         function addPath(testCase)
+            addpath(genpath([testCase.mp.path.falco filesep 'models']));
             addpath(genpath([testCase.mp.path.falco filesep 'setup']));
+            addpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
     end
     methods (TestClassTeardown)
         function removePath(testCase)
+            rmpath(genpath([testCase.mp.path.falco filesep 'models']))
             rmpath(genpath([testCase.mp.path.falco filesep 'setup']))
+            rmpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
-    end    
+    end  
     
 %% *Tests*
 

--- a/testing/tests_long/TestFunctionalZWFS.m
+++ b/testing/tests_long/TestFunctionalZWFS.m
@@ -19,16 +19,18 @@ classdef TestFunctionalZWFS < matlab.unittest.TestCase
 %
     methods (TestClassSetup)
         function addPath(testCase)
+            addpath(genpath([testCase.mp.path.falco filesep 'models']));
             addpath(genpath([testCase.mp.path.falco filesep 'setup']));
             addpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
     end
     methods (TestClassTeardown)
         function removePath(testCase)
+            rmpath(genpath([testCase.mp.path.falco filesep 'models']))
             rmpath(genpath([testCase.mp.path.falco filesep 'setup']))
             rmpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
-    end    
+    end
 
     
 %% *Tests*

--- a/testing/tests_long/TestIntegrationJacobianFLC.m
+++ b/testing/tests_long/TestIntegrationJacobianFLC.m
@@ -15,14 +15,18 @@ classdef TestIntegrationJacobianFLC < matlab.unittest.TestCase
 %
     methods (TestClassSetup)
         function addPath(testCase)
+            addpath(genpath([testCase.mp.path.falco filesep 'models']));
             addpath(genpath([testCase.mp.path.falco filesep 'setup']));
+            addpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
     end
     methods (TestClassTeardown)
         function removePath(testCase)
+            rmpath(genpath([testCase.mp.path.falco filesep 'models']))
             rmpath(genpath([testCase.mp.path.falco filesep 'setup']))
+            rmpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
-    end    
+    end
     
 %% *Tests*
 

--- a/testing/tests_long/TestIntegrationJacobianLC.m
+++ b/testing/tests_long/TestIntegrationJacobianLC.m
@@ -15,14 +15,18 @@ classdef TestIntegrationJacobianLC < matlab.unittest.TestCase
 %
     methods (TestClassSetup)
         function addPath(testCase)
+            addpath(genpath([testCase.mp.path.falco filesep 'models']));
             addpath(genpath([testCase.mp.path.falco filesep 'setup']));
+            addpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
     end
     methods (TestClassTeardown)
         function removePath(testCase)
+            rmpath(genpath([testCase.mp.path.falco filesep 'models']))
             rmpath(genpath([testCase.mp.path.falco filesep 'setup']))
+            rmpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
-    end    
+    end
     
 %% *Tests*
 

--- a/testing/tests_long/TestIntegrationJacobianVortex.m
+++ b/testing/tests_long/TestIntegrationJacobianVortex.m
@@ -15,14 +15,18 @@ classdef TestIntegrationJacobianVortex < matlab.unittest.TestCase
 %
     methods (TestClassSetup)
         function addPath(testCase)
+            addpath(genpath([testCase.mp.path.falco filesep 'models']));
             addpath(genpath([testCase.mp.path.falco filesep 'setup']));
+            addpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
     end
     methods (TestClassTeardown)
         function removePath(testCase)
+            rmpath(genpath([testCase.mp.path.falco filesep 'models']))
             rmpath(genpath([testCase.mp.path.falco filesep 'setup']))
+            rmpath(genpath([testCase.mp.path.falco filesep 'lib']));
         end
-    end    
+    end
     
 %% *Tests*
 %

--- a/testing/tests_long/TestPairwiseProbing.m
+++ b/testing/tests_long/TestPairwiseProbing.m
@@ -102,7 +102,7 @@ classdef TestPairwiseProbing < matlab.unittest.TestCase
             mp.est.probe.yOffset = 0;    % offset of probe center in y [actuators]. Use to avoid central obscurations.
             mp.est.probe.axis = 'alternate';     % which axis to have the phase discontinuity along [x or y or xy/alt/alternate]
             mp.est.probe.gainFudge = 1;     % empirical fudge factor to make average probe amplitude match desired value.
-            ev.dummy = 1;
+            ev.Itr = 1;
             ev = falco_est_pairwise_probing(mp, ev);
             Eest = ev.Eest;
             Eest2D = zeros(mp.Fend.Neta, mp.Fend.Nxi);
@@ -130,7 +130,7 @@ classdef TestPairwiseProbing < matlab.unittest.TestCase
             mp.est.probe.etaOffset = 0;
             mp.est.probe.width = 12;        
             mp.est.probe.height = 24;   
-            ev.dummy = 1;
+            ev.Itr = 1;
             ev = falco_est_pairwise_probing(mp, ev);
             Eest = ev.Eest;
             Eest2D = zeros(mp.Fend.Neta, mp.Fend.Nxi);


### PR DESCRIPTION
The ProbeSchedule class, if not left empty, allows the user to schedule the x- and y-offsets of the probes (at the DM) as well as the probe intensity at each WFSC iteration. It can be used like this:

```
mp.est.probeSchedule = ProbeSchedule;
mp.est.probeSchedule.xOffsetVec = [0, -6, 3];
mp.est.probeSchedule.yOffsetVec = [-6, 0, 3];
mp.est.probeSchedule.InormProbeVec = [1e-5, 1e-7, 1e-8];
```