### PR TITLE
Fixes to fiber-based implementation of EFC/iEFC

### DIFF
--- a/lib/wfsc/falco_est_delta_intensity.m
+++ b/lib/wfsc/falco_est_delta_intensity.m
@@ -28,9 +28,17 @@ function iefcStruct = falco_est_delta_intensity(mp, whichDM, dV, iJacMode)
         
         V0 = mp.dm1.V;
         mp.dm1.V = V0 + dV;
-        imagePlus = falco_get_sbp_image(mp, modvar.sbpIndex);
+        if ~mp.flagFiber
+            imagePlus = falco_get_sbp_image(mp, modvar.sbpIndex);
+        else
+            [~,imagePlus] = falco_get_sbp_image(mp, modvar.sbpIndex);
+        end
         mp.dm1.V = V0 - dV;
-        imageMinus = falco_get_sbp_image(mp, modvar.sbpIndex);
+        if ~mp.flagFiber
+            imageMinus = falco_get_sbp_image(mp, modvar.sbpIndex);
+        else
+            [~,imageMinus] = falco_get_sbp_image(mp, modvar.sbpIndex);
+        end
         mp.dm1.V = V0; % reset;
         
     elseif whichDM == 2
@@ -52,9 +60,14 @@ function iefcStruct = falco_est_delta_intensity(mp, whichDM, dV, iJacMode)
         figure(1005); imagesc(log10(abs(DI2D))); axis xy equal tight; colorbar; drawnow;
         figure(1006); imagesc(angle(DI2D)); axis xy equal tight; colorbar; drawnow;
     end
-
-    iefcStruct.DeltaI = DI2D(mp.Fend.corr.maskBool).';
-    iefcStruct.imagePlus = imagePlus;
-    iefcStruct.imageMinus = imageMinus;
     
+    if ~mp.flagFiber
+        iefcStruct.DeltaI = DI2D(mp.Fend.corr.maskBool).';
+        iefcStruct.imagePlus = imagePlus;
+        iefcStruct.imageMinus = imageMinus;
+    else
+        iefcStruct.DeltaI = DI2D;
+        iefcStruct.imagePlus = imagePlus;
+        iefcStruct.imageMinus = imageMinus;
+    end
 end %--END OF FUNCTION

--- a/lib/wfsc/falco_est_iefc.m
+++ b/lib/wfsc/falco_est_iefc.m
@@ -23,8 +23,14 @@ function ev = falco_est_iefc(mp)
 
     Nprobes = size(mp.iefc.probeCube, 3);
     
-    ev.Eest = zeros(Nprobes*mp.Fend.corr.Npix, mp.jac.Nmode);
-    ev.IincoEst = zeros(mp.Fend.corr.Npix, mp.jac.Nmode);
+    if ~mp.flagFiber
+        ev.Eest = zeros(Nprobes*mp.Fend.corr.Npix, mp.jac.Nmode);
+        ev.IincoEst = zeros(mp.Fend.corr.Npix, mp.jac.Nmode);
+    else
+        ev.Eest = zeros(Nprobes*mp.Fend.Nfiber, mp.jac.Nmode);
+        ev.IincoEst = zeros(mp.Fend.Nfiber, mp.jac.Nmode);
+    end
+    
     ev.Im = zeros(mp.Fend.Neta, mp.Fend.Nxi);
     ev.imageArray = zeros(mp.Fend.Neta, mp.Fend.Nxi, 1+2*Nprobes, mp.jac.Nmode);
 
@@ -34,7 +40,13 @@ function ev = falco_est_iefc(mp)
             
             dV = mp.iefc.probeCoef * mp.iefc.probeCube(:, :, iProbe);
             iefcStruct = falco_est_delta_intensity(mp, mp.iefc.probeDM, dV, iJacMode);
-            ev.Eest((iProbe-1)*mp.Fend.corr.Npix+1:iProbe*mp.Fend.corr.Npix, iJacMode) = iefcStruct.DeltaI / mp.iefc.probeCoef;
+            
+            if ~mp.flagFiber
+                ev.Eest((iProbe-1)*mp.Fend.corr.Npix+1:iProbe*mp.Fend.corr.Npix, iJacMode) = iefcStruct.DeltaI / mp.iefc.probeCoef;
+            else
+                ev.Eest((iProbe-1)*mp.Fend.Nfiber+1:iProbe*mp.Fend.Nfiber, iJacMode) = iefcStruct.DeltaI / mp.iefc.probeCoef;
+            end
+
             ev.imageArray(:, :, 1+2*(iProbe-1)+1, mp.jac.Nmode) = iefcStruct.imagePlus;
             ev.imageArray(:, :, 1+2*(iProbe-1)+2, mp.jac.Nmode) = iefcStruct.imageMinus;
         end        

--- a/lib/wfsc/falco_store_intensities.m
+++ b/lib/wfsc/falco_store_intensities.m
@@ -12,7 +12,11 @@
 function out = falco_store_intensities(mp, out, ev, Itr)
     
     if strcmpi(mp.estimator, 'iefc')
-        ev.Eest = zeros(mp.Fend.corr.Npix, mp.jac.Nmode);
+        if ~mp.flagFiber
+            ev.Eest = zeros(mp.Fend.corr.Npix, mp.jac.Nmode);
+        else
+            ev.Eest = zeros(mp.Fend.Nfiber, mp.jac.Nmode);
+        end
     end
 
     % Apply subband weights and then sum over subbands

--- a/models/model_Jacobian_IEFC.m
+++ b/models/model_Jacobian_IEFC.m
@@ -23,8 +23,12 @@ function jac = model_Jacobian_IEFC(mp, whichDM)
     if whichDM == 1
         
         V0 = mp.dm1.V;
-        jac = zeros(Nprobes*mp.Fend.corr.Npix, mp.dm1.Nele, mp.jac.Nmode); %--Initialize the Jacobian
-
+        if ~mp.flagFiber
+            jac = zeros(Nprobes*mp.Fend.corr.Npix, mp.dm1.Nele, mp.jac.Nmode); %--Initialize the Jacobian
+        else
+            jac = zeros(Nprobes*mp.Fend.Nfiber, mp.dm1.Nele, mp.jac.Nmode); %--Initialize the Jacobian
+        end
+        
         for iJacMode = 1:mp.jac.Nmode
 
             for iBasisMode = 1:mp.dm1.NbasisModes
@@ -42,18 +46,36 @@ function jac = model_Jacobian_IEFC(mp, whichDM)
                     minusStruct = falco_est_delta_intensity(mp, mp.iefc.probeDM, dVprobe, iJacMode);
                     mp.dm1.V = V0; % reset
 
-                    jac((iProbe-1)*mp.Fend.corr.Npix+1:iProbe*mp.Fend.corr.Npix, iBasisMode, iJacMode) = (plusStruct.DeltaI - minusStruct.DeltaI)/(2*mp.iefc.modeCoef*mp.iefc.probeCoef);
+                    if ~mp.flagFiber
+                        jac((iProbe-1)*mp.Fend.corr.Npix+1:iProbe*mp.Fend.corr.Npix, iBasisMode, iJacMode) = (plusStruct.DeltaI - minusStruct.DeltaI)/(2*mp.iefc.modeCoef*mp.iefc.probeCoef);
 
-                    if flagPlot
-                        figure(30); imagesc(dVmode); axis xy equal tight; colorbar; 
-                        title(sprintf('Basis Mode %d/%d', iBasisMode, Nbasis));
-                        drawnow;
+                        if flagPlot
+                            figure(30); imagesc(dVbasis); axis xy equal tight; colorbar; 
+                            title(sprintf('Basis Mode %d/%d', iBasisMode, mp.dm1.NbasisModes));
+                            drawnow;
 
-                        E2D = zeros(mp.Fend.Nxi, mp.Fend.Neta);
-                        E2D(mp.Fend.corr.maskBool) = jac(1:mp.Fend.corr.Npix, iBasisMode, iJacMode);
-                        figure(31); imagesc(log10(abs(E2D))); axis xy equal tight; colorbar; 
-                        title(sprintf('Basis Mode %d/%d', iBasisMode, Nbasis));
-                        drawnow;
+                            E2D = zeros(mp.Fend.Nxi, mp.Fend.Neta);
+                            E2D(mp.Fend.corr.maskBool) = jac(1:mp.Fend.corr.Npix, iBasisMode, iJacMode);
+                            figure(31); imagesc(log10(abs(E2D))); axis xy equal tight; colorbar; 
+                            title(sprintf('Basis Mode %d/%d', iBasisMode, mp.dm1.NbasisModes));
+                            drawnow;
+                        end
+                    else
+                         jac((iProbe-1)*mp.Fend.Nfiber+1:iProbe*mp.Fend.Nfiber, iBasisMode, iJacMode) = (plusStruct.DeltaI - minusStruct.DeltaI)/(2*mp.iefc.modeCoef*mp.iefc.probeCoef);
+
+                        if flagPlot
+                            figure(30); imagesc(dVbasis); axis xy equal tight; colorbar; 
+                            title(sprintf('Basis Mode %d/%d', iBasisMode, mp.dm1.NbasisModes));
+                            drawnow;
+
+                            E2D = zeros(mp.Fend.Nxi, mp.Fend.Neta);
+%                             E2D(mp.Fend.corr.maskBool) = jac(1:mp.Fend.Nfiber, iBasisMode, iJacMode);
+                            E2D = jac(1:mp.Fend.Nfiber, iBasisMode, iJacMode);
+
+                            figure(31); imagesc(log10(abs(E2D))); axis xy equal tight; colorbar; 
+                            title(sprintf('Basis Mode %d/%d', iBasisMode, mp.dm1.NbasisModes));
+                            drawnow;
+                        end
                     end
 
                 end  


### PR DESCRIPTION
- Fixes issue of FALCO scripts using `mp.Fend.corr.Npix` instead of `mp.Fend.Nfiber` for fiber-based simulations
- Fixes bug when plotting the basis modes