### PR TITLE
DZM Bug fix for requirement of tb object

### DIFF
--- a/lib/wfsc/falco_est_ekf_maintenance.m
+++ b/lib/wfsc/falco_est_ekf_maintenance.m
@@ -66,12 +66,16 @@ if any(mp.dm_ind == 1)
     mp.dm1 = falco_set_constrained_voltage(mp.dm1, mp.dm1.V_dz + mp.dm1.V_drift + mp.dm1.dV + DM1Vdither + mp.dm1.V_shift); 
 elseif any(mp.dm_drift_ind == 1)
     mp.dm1 = falco_set_constrained_voltage(mp.dm1, mp.dm1.V_dz + mp.dm1.V_drift); 
+elseif any(mp.dm_ind_static == 1)
+    mp.dm1 = falco_set_constrained_voltage(mp.dm1, mp.dm1.V_dz);
 end
 
 if any(mp.dm_ind == 2)
     mp.dm2 = falco_set_constrained_voltage(mp.dm2, mp.dm2.V_dz + mp.dm2.V_drift + mp.dm2.dV + DM2Vdither + mp.dm2.V_shift); 
 elseif any(mp.dm_drift_ind == 2)
     mp.dm2 = falco_set_constrained_voltage(mp.dm2, mp.dm2.V_dz + mp.dm2.V_drift); 
+elseif any(mp.dm_ind_static == 2)
+    mp.dm2 = falco_set_constrained_voltage(mp.dm2, mp.dm2.V_dz);
 end
 
 % Do safety check to make sure no actuators are pinned
@@ -133,8 +137,16 @@ else
 end
 
 %% Remove control from DM command so that controller images are correct
-if any(mp.dm_ind == 1);  mp.dm1 = falco_set_constrained_voltage(mp.dm1, mp.dm1.V_dz + mp.dm1.V_drift + DM1Vdither + mp.dm1.V_shift);end
-if any(mp.dm_ind == 2);  mp.dm2 = falco_set_constrained_voltage(mp.dm2, mp.dm2.V_dz + mp.dm2.V_drift + DM2Vdither + mp.dm2.V_shift);end
+if any(mp.dm_ind == 1)
+    mp.dm1 = falco_set_constrained_voltage(mp.dm1, mp.dm1.V_dz + mp.dm1.V_drift + DM1Vdither + mp.dm1.V_shift);
+elseif any(mp.dm_ind_static == 1)
+    mp.dm1 = falco_set_constrained_voltage(mp.dm1, mp.dm1.V_dz);
+end
+if any(mp.dm_ind == 2) 
+    mp.dm2 = falco_set_constrained_voltage(mp.dm2, mp.dm2.V_dz + mp.dm2.V_drift + DM2Vdither + mp.dm2.V_shift);
+elseif any(mp.dm_ind_static == 2)
+    mp.dm2 = falco_set_constrained_voltage(mp.dm2, mp.dm2.V_dz);
+end
 
 save_ekf_data(mp,ev,DM1Vdither, DM2Vdither)
 
@@ -270,13 +282,13 @@ function [mp,ev] = get_open_loop_data(mp,ev)
 % used for control, apply V_dz
 if (any(mp.dm_drift_ind == 1) && any(mp.dm_ind == 1)) || any(mp.dm_drift_ind == 1)
     mp.dm1 = falco_set_constrained_voltage(mp.dm1, mp.dm1.V_dz + mp.dm1.V_drift);
-elseif any(mp.dm_ind == 1) 
+elseif any(mp.dm_ind == 1) || any(mp.dm_ind_static == 1)
     mp.dm1 = falco_set_constrained_voltage(mp.dm1, mp.dm1.V_dz);
 end
 
 if (any(mp.dm_drift_ind == 2) && any(mp.dm_ind == 2)) || any(mp.dm_drift_ind == 2)
     mp.dm2 = falco_set_constrained_voltage(mp.dm2, mp.dm2.V_dz + mp.dm2.V_drift);
-elseif any(mp.dm_ind == 2) 
+elseif any(mp.dm_ind == 2) || any(mp.dm_ind_static == 2)
     mp.dm2 = falco_set_constrained_voltage(mp.dm2, mp.dm2.V_dz);
 end
 

--- a/lib/wfsc/falco_wfsc_loop.m
+++ b/lib/wfsc/falco_wfsc_loop.m
@@ -182,8 +182,10 @@ for Itr = 1:mp.Nitr
         break;
     end
     % sfr
-    figure(111)
-    semilogy(out.IrawScoreHist);hold on; semilogy(out.IOLScoreHist);hold off;
+    if strcmpi(mp.estimator,'ekf_maintenance') && Itr > 1 
+        figure(111)
+        semilogy(out.IrawScoreHist);hold on; semilogy(ev.IOLScoreHist);hold off;
+    end
 end %--END OF ESTIMATION + CONTROL LOOP
 
 Itr = mp.Nitr;

--- a/lib/wfsc/falco_wfsc_loop.m
+++ b/lib/wfsc/falco_wfsc_loop.m
@@ -181,11 +181,7 @@ for Itr = 1:mp.Nitr
     if flagBreak
         break;
     end
-    % sfr
-    if strcmpi(mp.estimator,'ekf_maintenance') && Itr > 1 
-        figure(111)
-        semilogy(out.IrawScoreHist);hold on; semilogy(ev.IOLScoreHist);hold off;
-    end
+
 end %--END OF ESTIMATION + CONTROL LOOP
 
 Itr = mp.Nitr;
@@ -292,9 +288,19 @@ function [out, hProgress] = plot_wfsc_progress(mp, out, ev, hProgress, Itr, ImSi
     if any(mp.dm_ind == 1); DM1surf = falco_gen_dm_surf(mp.dm1, mp.dm1.compact.dx, mp.dm1.compact.Ndm); else; DM1surf = zeros(mp.dm1.compact.Ndm); end
     if any(mp.dm_ind == 2); DM2surf = falco_gen_dm_surf(mp.dm2, mp.dm2.compact.dx, mp.dm2.compact.Ndm); else; DM2surf = zeros(mp.dm2.compact.Ndm); end
     
-    % Add open loop contrast history to out variable.
+    % Plot open loop contrast if dark zone maintenance is running
     if strcmpi(mp.estimator,'ekf_maintenance') 
         out.IOLScoreHist = ev.IOLScoreHist;
+        figure(111)
+        semilogy([1:1:Itr], out.IrawScoreHist(1:Itr), '-*');hold on; 
+        semilogy([1:1:Itr], out.IOLScoreHist(1:Itr), '-p');hold off;
+        legend('closed loop', 'open loop')
+        xlim([0,mp.Nitr])
+        xlabel('iteration')
+        ylabel('contrast')
+        title('Contrast vs Iteration')
+        set(gca,'FontSize',16 ,'FontName','Times','FontWeight','Normal')
+        drawnow;
     end
     
     if isfield(mp, 'testbed')

--- a/lib/wfsc/falco_wfsc_loop.m
+++ b/lib/wfsc/falco_wfsc_loop.m
@@ -181,7 +181,9 @@ for Itr = 1:mp.Nitr
     if flagBreak
         break;
     end
-
+    % sfr
+    figure(111)
+    semilogy(out.IrawScoreHist);hold on; semilogy(out.IOLScoreHist);hold off;
 end %--END OF ESTIMATION + CONTROL LOOP
 
 Itr = mp.Nitr;

--- a/lib/wfsc/falco_wfsc_loop.m
+++ b/lib/wfsc/falco_wfsc_loop.m
@@ -291,16 +291,18 @@ function [out, hProgress] = plot_wfsc_progress(mp, out, ev, hProgress, Itr, ImSi
     % Plot open loop contrast if dark zone maintenance is running
     if strcmpi(mp.estimator,'ekf_maintenance') 
         out.IOLScoreHist = ev.IOLScoreHist;
-        figure(111)
-        semilogy([1:1:Itr], out.IrawScoreHist(1:Itr), '-*');hold on; 
-        semilogy([1:1:Itr], out.IOLScoreHist(1:Itr), '-p');hold off;
-        legend('closed loop', 'open loop')
-        xlim([0,mp.Nitr])
-        xlabel('iteration')
-        ylabel('contrast')
-        title('Contrast vs Iteration')
-        set(gca,'FontSize',16 ,'FontName','Times','FontWeight','Normal')
-        drawnow;
+        if(mp.flagPlot)
+            figure(111)
+            semilogy([1:1:Itr], out.IrawScoreHist(1:Itr), '-*');hold on; 
+            semilogy([1:1:Itr], out.IOLScoreHist(1:Itr), '-p');hold off;
+            legend('closed loop', 'open loop')
+            xlim([0,mp.Nitr])
+            xlabel('iteration')
+            ylabel('contrast')
+            title('Contrast vs Iteration')
+            set(gca,'FontSize',16 ,'FontName','Times','FontWeight','Normal')
+            drawnow;
+        end
     end
     
     if isfield(mp, 'testbed')

--- a/lib/wfsc/initialize_ekf_maintenance.m
+++ b/lib/wfsc/initialize_ekf_maintenance.m
@@ -30,7 +30,7 @@ ev.G_tot_cont = rearrange_jacobians(mp,jacStruct,mp.dm_ind);
 ev.G_tot_drift = rearrange_jacobians(mp,jacStruct,mp.dm_drift_ind);
 
 % Initialize EKF matrices
-ev = initialize_ekf_matrices(mp, ev);
+ev = initialize_ekf_matrices(mp, ev, sbp_texp);
 
 % Initialize pinned actuator check
 ev.dm1.initial_pinned_actuators = mp.dm1.pinned;
@@ -84,7 +84,7 @@ G_tot = [G1, G2];
 
 end
 
-function ev = initialize_ekf_matrices(mp, ev)
+function ev = initialize_ekf_matrices(mp, ev, sbp_texp)
 
 % Below are the defnitions of the EKF matrices. There are multiple EKFs 
 % defined in parallel.
@@ -121,7 +121,7 @@ for iSubband = 1:1:mp.Nsbp
     dm_drift_covariance = eye(size(G_reordered,2))*(mp.drift.presumed_dm_std^2);
 
     for i = 0:1:floor(ev.SL/ev.BS)-1
-        ev.Q(:,:,i+1,iSubband) = G_reordered((i)*ev.BS+1:(i+1)*ev.BS,:)*dm_drift_covariance*G_reordered(i*ev.BS+1:(i+1)*ev.BS,:).'*mp.tb.info.sbp_texp(iSubband)*(ev.e_scaling(iSubband)^2);
+        ev.Q(:,:,i+1,iSubband) = G_reordered((i)*ev.BS+1:(i+1)*ev.BS,:)*dm_drift_covariance*G_reordered(i*ev.BS+1:(i+1)*ev.BS,:).'*sbp_texp(iSubband)*(ev.e_scaling(iSubband)^2);
     end
 end
 
@@ -147,12 +147,12 @@ for iSubband = 1:1:mp.Nsbp
     end
 
     % Save initial ev state:
-    ev.x_hat0(1:ev.SS:end,iSubband) = real(E_hat) * ev.e_scaling(iSubband) * sqrt(mp.tb.info.sbp_texp(iSubband));
-    ev.x_hat0(2:ev.SS:end,iSubband) = imag(E_hat) * ev.e_scaling(iSubband) * sqrt(mp.tb.info.sbp_texp(iSubband));
+    ev.x_hat0(1:ev.SS:end,iSubband) = real(E_hat) * ev.e_scaling(iSubband) * sqrt(sbp_texp(iSubband));
+    ev.x_hat0(2:ev.SS:end,iSubband) = imag(E_hat) * ev.e_scaling(iSubband) * sqrt(sbp_texp(iSubband));
 
     % The EKF state is scaled such that the intensity is measured in photons:
-    ev.x_hat(1:ev.SS:end,iSubband) = real(E_hat) * ev.e_scaling(iSubband) * sqrt(mp.tb.info.sbp_texp(iSubband));
-    ev.x_hat(2:ev.SS:end,iSubband) = imag(E_hat) * ev.e_scaling(iSubband) * sqrt(mp.tb.info.sbp_texp(iSubband));
+    ev.x_hat(1:ev.SS:end,iSubband) = real(E_hat) * ev.e_scaling(iSubband) * sqrt(sbp_texp(iSubband));
+    ev.x_hat(2:ev.SS:end,iSubband) = imag(E_hat) * ev.e_scaling(iSubband) * sqrt(sbp_texp(iSubband));
  end
 
 end

--- a/main/EXAMPLE_main_dark_zone_maintenance.m
+++ b/main/EXAMPLE_main_dark_zone_maintenance.m
@@ -16,7 +16,7 @@ mp.dm_ind_static = [2]; %--DMs ONLY holding dark zone shape, not injecting drift
 mp.estimator = 'ekf_maintenance';
 mp.est.probe.Npairs = 1; 
 mp.est.probe.whichDM = 1; %--Which DM is used for dither/control
-mp.est.dither = 9.5e-4; %--std dev of dither command for random dither [V/sqtr(iter)]
+mp.est.dither = 9.5e-5; %--std dev of dither command for random dither [V/sqtr(iter)]
 mp.est.flagUseJac = true; % EKF needs the jacobian for estimation 
 mp.est.read_noise = 1; %--Read noise of detector [e-]
 mp.est.dark_current = 0.01; %--Dark current of detector [e-/s]
@@ -37,7 +37,7 @@ mp.relinItrVec = [1];
 %%-- Drift variables 
 mp.dm_drift_ind = 1;%--which DM is drifting 
 mp.drift.type = 'rand_walk';%--what type of drift is happening 
-mp.drift.magnitude = 9e-5; %--std dev of random walk [V/sqrt(iter)]
+mp.drift.magnitude = 9e-6; %--std dev of random walk [V/sqrt(iter)]
 mp.drift.presumed_dm_std = mp.drift.magnitude; %--std dev of random walk provided to estimator, change this to account for the uncertainty of the drift magnitude
 
 %%--

--- a/main/EXAMPLE_main_dark_zone_maintenance.m
+++ b/main/EXAMPLE_main_dark_zone_maintenance.m
@@ -57,7 +57,7 @@ mp.dm1.V_shift = zeros(mp.dm1.Nact); %--DM shift command for estimator reset to 
 mp.dm2.V_shift = zeros(mp.dm2.Nact);
 
 %% Change run label and FALCO output paths
-mp.runLabel = ['dark_zone_maintenance'];
+mp.runLabel = ['DZM'];
 
 out_dir = fullfile(mp.path.config,mp.runLabel);
 mp.path.config = out_dir;  %--Location of *config.mat and *snippet.mat output files

--- a/main/EXAMPLE_main_dark_zone_maintenance.m
+++ b/main/EXAMPLE_main_dark_zone_maintenance.m
@@ -4,26 +4,18 @@
 
 EXAMPLE_try_running_FALCO
 
-% Option 2: Load DM command from previous experiment 
-
-% mp.SeriesNum = 8;
-% mp.TrialNum = 65;
-% dhmStartSoln.SeriesNum = mp.SeriesNum; % Series number of previous DM solution 
-% dhmStartSoln.TrialNum = mp.TrialNum; % Trial number of previous DM solution 
-% dhmStartSoln.itNum = NaN; % Iteration number for previous DM solution 
-% 
-% load(fullfile(tb.info.OUT_DATA_DIR,['Series',num2str(dhmStartSoln.SeriesNum),'_Trial',num2str(dhmStartSoln.TrialNum)], ...
-%     ['Series',num2str(dhmStartSoln.SeriesNum),'_Trial',num2str(dhmStartSoln.TrialNum),'_config.mat']))
-% mp = loadPrevDMsoln(mp, dhmStartSoln, tb.info.OUT_DATA_DIR );
+% Option 2: Load DM command from previous experiment, load mp and out variables 
 
 %% Step 2: Set variables for DZM
 
 mp.Nitr = 100; % Number of iteration for EKF 
+mp.dm_ind = 1; %--DMs used in estimation/control
+mp.dm_ind_static = [2]; %--DMs ONLY holding dark zone shape, not injecting drift or part of control
 
 %%-- Variables for ekf maintenance estimation
 mp.estimator = 'ekf_maintenance';
 mp.est.probe.Npairs = 1; 
-mp.est.probe.whichDM = 1; %--Which DM is used for control
+mp.est.probe.whichDM = 1; %--Which DM is used for dither/control
 mp.est.dither = 9.5e-4; %--std dev of dither command for random dither [V/sqtr(iter)]
 mp.est.flagUseJac = true; % EKF needs the jacobian for estimation 
 mp.est.read_noise = 1; %--Read noise of detector [e-]
@@ -40,10 +32,10 @@ mp.ctrl.dmfacVec = 1;
 % Set EFC tikhonov parameter 
 mp.ctrl.sched_mat = repmat([1, -1.0, 1, 1, 0], [mp.Nitr, 1]);% 
 [mp.Nitr, mp.relinItrVec, mp.gridSearchItrVec, mp.ctrl.log10regSchedIn, mp.dm_ind_sched] = falco_ctrl_EFC_schedule_generator(mp.ctrl.sched_mat);
-mp.relinItrVec = [];
+mp.relinItrVec = [1];
 
 %%-- Drift variables 
-mp.dm_drift_ind = mp.dm_ind;%--which DM is drifting 
+mp.dm_drift_ind = 1;%--which DM is drifting 
 mp.drift.type = 'rand_walk';%--what type of drift is happening 
 mp.drift.magnitude = 9e-5; %--std dev of random walk [V/sqrt(iter)]
 mp.drift.presumed_dm_std = mp.drift.magnitude; %--std dev of random walk provided to estimator, change this to account for the uncertainty of the drift magnitude
@@ -60,13 +52,14 @@ mp.dm2.V_dz = mp.dm2.V;
 mp.dm1.V_drift = zeros(mp.dm1.Nact); %--Drift injected, initialize to 0
 mp.dm2.V_drift = zeros(mp.dm2.Nact);
 
+
 mp.dm1.V_shift = zeros(mp.dm1.Nact); %--DM shift command for estimator reset to avoid linearization / phase wrapping errors, initialize to zero
 mp.dm2.V_shift = zeros(mp.dm2.Nact);
 
 %% Change run label and FALCO output paths
-mp.runLabel = ['EKF_Series',num2str(mp.SeriesNum),'_Trial',num2str(mp.TrialNum)];
+mp.runLabel = ['dark_zone_maintenance'];
 
-out_dir = fullfile(tb.info.OUT_DATA_DIR,mp.runLabel);
+out_dir = fullfile(mp.path.config,mp.runLabel);
 mp.path.config = out_dir;  %--Location of *config.mat and *snippet.mat output files
 mp.path.ws = out_dir; % Location for (mostly) complete workspace from end of trial, *_all.mat
 


### PR DESCRIPTION
Previous version of the DZM ekf depended on testbed object to get exposure time, this is corrected.  Also if a DM is kept static, that is tracked.